### PR TITLE
Fix sort icon for component field type

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -10,8 +10,8 @@
               </th>
               <th v-if="extractName(field.name) == '__component'"
                   @click="orderBy(field, $event)"
-                  :class="[field.titleClass, {'sortable': isSortable(field)}]"
-                  v-html="field.title || ''">
+                  :class="[field.titleClass, {'sortable': isSortable(field)}]">
+                  {{ field.title || '' }}
                   <i v-if="isCurrentSortField(field) && field.title"
                      :class="sortIcon(field)"
                      :style="{opacity: sortIconOpacity(field)}"></i>


### PR DESCRIPTION
If we have sortable __component field type, sort icon is not displaying because it is overwritten by v-html directive used to render the content of **th** element. 

This patch solves the problem by simply echoing out field title (if provided) instead of using v-html directive.