### PR TITLE
Pass action column content from parent via scoped slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ with follow-along project [here](https://github.com/ratiw/vuetable-2-tutorial). 
 If you've been using Vuetable for Vue 1.x before, checkout [what's changed](https://github.com/ratiw/vuetable-2/blob/master/changes.md) for info on changes from Vuetable for Vue 1.x and the [upgrade guide](https://github.com/ratiw/vuetable-2/blob/master/upgrade-guide.md) on how you could upgrade from Vuetable for Vue 1.x.
 
 Original version works great but wanted to be able to define action buttons per instance of a data table without depending on a globally defined component. I did this by adding a slot in place of the component that was used in the vuetable.vue.
+
+Use scoped slot in parent when defining the actions [Vue Doc for scopped Slots](https://vuejs.org/v2/guide/components.html#Scoped-Slots)
+
+e.g. 
+```html
+<template slot="actions" scope="props">
+    <div class="table-button-container">
+        <button class="btn btn-default" @click="onClick('edit-item', props.rowData)"><i class="fa fa-edit"></i> View</button>&nbsp;&nbsp;
+        <button class="btn btn-danger" @click="onClick('delete-item', props.rowData)"><i class="fa fa-remove"></i> Edit</button>&nbsp;&nbsp;
+    </div>
+</template>
+```
+
+the onClick function can now be defined in the parent and the parent has Access to rowData and rowIndex via props. :)

--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ with follow-along project [here](https://github.com/ratiw/vuetable-2-tutorial). 
 
 If you've been using Vuetable for Vue 1.x before, checkout [what's changed](https://github.com/ratiw/vuetable-2/blob/master/changes.md) for info on changes from Vuetable for Vue 1.x and the [upgrade guide](https://github.com/ratiw/vuetable-2/blob/master/upgrade-guide.md) on how you could upgrade from Vuetable for Vue 1.x.
 
+Original version works great but wanted to be able to define action buttons per instance of a data table without depending on a globally defined component. I did this by adding a slot in place of the <component><component> that was used in the vuetable.vue.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ with follow-along project [here](https://github.com/ratiw/vuetable-2-tutorial). 
 
 If you've been using Vuetable for Vue 1.x before, checkout [what's changed](https://github.com/ratiw/vuetable-2/blob/master/changes.md) for info on changes from Vuetable for Vue 1.x and the [upgrade guide](https://github.com/ratiw/vuetable-2/blob/master/upgrade-guide.md) on how you could upgrade from Vuetable for Vue 1.x.
 
-Original version works great but wanted to be able to define action buttons per instance of a data table without depending on a globally defined component. I did this by adding a slot in place of the <component><component> that was used in the vuetable.vue.
+Original version works great but wanted to be able to define action buttons per instance of a data table without depending on a globally defined component. I did this by adding a slot in place of the component that was used in the vuetable.vue.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ e.g.
 ```
 
 the onClick function can now be defined in the parent and the parent has Access to rowData and rowIndex via props. :)
+
+The original functionality still works 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -18,6 +18,14 @@
                      :class="sortIcon(field)"
                      :style="{opacity: sortIconOpacity(field)}"></i>
               </th>
+              <th v-if="extractName(field.name) == '__slot'"
+                  @click="orderBy(field, $event)"
+                  :class="['vuetable-th-slot-'+trackBy, field.titleClass, {'sortable': isSortable(field)}]">
+                  {{ field.title || '' }}
+                  <i v-if="isInCurrentSortGroup(field) && field.title"
+                     :class="sortIcon(field)"
+                     :style="{opacity: sortIconOpacity(field)}"></i>
+              </th>
               <th v-if="extractName(field.name) == '__sequence'"
                   :class="['vuetable-th-sequence', field.titleClass || '']" v-html="field.title || ''">
               </th>
@@ -55,9 +63,10 @@
                     :checked="rowSelected(item, field.name)">
                 </td>
                 <td v-if="extractName(field.name) === '__component'" :class="['vuetable-component', field.dataClass]">
-                  <slot name='actions' :row-data="item" :row-index="index">
                     <component :is="extractArgs(field.name)" :row-data="item" :row-index="index"></component>
-                  </slot>
+                </td>
+                <td v-if="extractName(field.name) === '__slot'" :class="['vuetable-slot', field.dataClass]">
+                  <slot :name="extractArgs(field.name)" :row-data="item" :row-index="index"></slot>
                 </td>
               </template>
               <template v-else>

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -29,7 +29,7 @@
               <th v-if="extractName(field.name) == '__sequence'"
                   :class="['vuetable-th-sequence', field.titleClass || '']" v-html="field.title || ''">
               </th>
-              <th v-if="notIn(extractName(field.name), ['__sequence', '__checkbox', '__component'])"
+              <th v-if="notIn(extractName(field.name), ['__sequence', '__checkbox', '__component', '__slot'])"
                   :class="['vuetable-th-'+field.name, field.titleClass || '']" v-html="field.title || ''">
               </th>
             </template>

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -55,7 +55,7 @@
                     :checked="rowSelected(item, field.name)">
                 </td>
                 <td v-if="extractName(field.name) === '__component'" :class="['vuetable-component', field.dataClass]">
-                  <component :is="extractArgs(field.name)" :row-data="item" :row-index="index"></component>
+                  <slot name='actions' :row-data="item" :row-index="index"></slot>
                 </td>
               </template>
               <template v-else>

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -55,7 +55,9 @@
                     :checked="rowSelected(item, field.name)">
                 </td>
                 <td v-if="extractName(field.name) === '__component'" :class="['vuetable-component', field.dataClass]">
-                  <slot name='actions' :row-data="item" :row-index="index"></slot>
+                  <slot name='actions' :row-data="item" :row-index="index">
+                    <component :is="extractArgs(field.name)" :row-data="item" :row-index="index"></component>
+                  </slot>
                 </td>
               </template>
               <template v-else>


### PR DESCRIPTION
Added a none breaking change that makes it possible to not depend on a globally defined action column component.
One can pass the action column content via the 'actions' slot and define the methods locally on the parent. 
Like:
```html
<template slot="actions" scope="props">
     <div class="table-button-container">
           <button class="btn btn-default" @click="onClick('edit-item', props.rowData)"><i class="fa fa-edit"></i> View</button>&nbsp;&nbsp;
           <button class="btn btn-danger" @click="onClick('delete-item', props.rowData)"><i class="fa fa-remove"></i> Edit</button>&nbsp;&nbsp;
     </div>
</template>
```
Original functionality still works.
[VueJS Docs for scoped slots](https://vuejs.org/v2/guide/components.html#Scoped-Slots)