### PR TITLE
Add column's filters under column's names

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -84,12 +84,14 @@ let tableColumns = [
   {
     name: 'name',
     title: 'Full Name',
-    sortField: 'name'
+    sortField: 'name',
+    searchField: true,
   },
   {
     name: 'email',
     sortField: 'email',
-    visible: true
+    visible: true,
+    searchField: true,
   },
   {
     name: 'nickname',


### PR DESCRIPTION
Hi @ratiw,

I do that : https://github.com/ratiw/vuetable-2/issues/49

For this to work, you must add this value 

> searchField:true

  to a column for add a input filter under column.

In api route i have put this code :
`
    if ($request->exists('filter') && $request->exists('filterOn') ) {
        if(Schema::hasColumn('users', $request['filterOn'])) {
            $query->where(function ($q) use ($request) {
                $value = "%{$request->filter}%";
                $q->where($request['filterOn'], 'like', $value);
            });
        }
    }`

What do you think ?
