### PR TITLE
fixed: TypeError: els.forEach is not a function when rendering checkbox

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -608,6 +608,11 @@ export default {
       let selector = 'th.vuetable-th-checkbox-' + idColumn + ' input[type=checkbox]'
       let els = document.querySelectorAll(selector)
 
+      //fixed:document.querySelectorAll return the typeof nodeList not array
+      els.forEach=function(cb){
+        [].forEach.call(els, cb);
+      }
+
       // count how many checkbox row in the current page has been checked
       let selected = this.tableData.filter(function(item) {
         return self.selectedTo.indexOf(item[idColumn]) >= 0

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -609,9 +609,10 @@ export default {
       let els = document.querySelectorAll(selector)
 
       //fixed:document.querySelectorAll return the typeof nodeList not array
-      els.forEach=function(cb){
-        [].forEach.call(els, cb);
-      }
+      if (els.forEach===undefined)
+        els.forEach=function(cb){
+          [].forEach.call(els, cb);
+        }
 
       // count how many checkbox row in the current page has been checked
       let selected = this.tableData.filter(function(item) {


### PR DESCRIPTION
fixed: TypeError: els.forEach is not a function for :
document.querySelectorAll return the typeof nodeList not array
also fixed for :https://github.com/ratiw/vuetable-2-tutorial/issues/18
…--bajian <313066164@qq.com>