### PR TITLE
Pass in sort field to components

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -63,7 +63,7 @@
                     :checked="rowSelected(item, field.name)">
                 </td>
                 <td v-if="extractName(field.name) === '__component'" :class="['vuetable-component', field.dataClass]">
-                    <component :is="extractArgs(field.name)" :row-data="item" :row-index="index"></component>
+                    <component :is="extractArgs(field.name)" :row-field="field.sortField" :row-data="item" :row-index="index"></component>
                 </td>
                 <td v-if="extractName(field.name) === '__slot'" :class="['vuetable-slot', field.dataClass]">
                   <slot :name="extractArgs(field.name)" :row-data="item" :row-index="index"></slot>


### PR DESCRIPTION
Hey,

I passed in the `sortField` prop to the `__component` because I needed a way to get the SQL field for one of the components I built for an application.  I believe this would be useful for others as well.

My use case was an editable field that I built with a component.  This field, when double clicked on changes to an input to allow the user to edit the field.  Once the user clicks save, the changed are sent to the server.  I need the `sortField` prop in order for my server to understand what field was being edited.

Thanks!