### PR TITLE
Dynamic slot detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,16 @@
                       @vuetable:loading="showLoader"
                       @vuetable:loaded="hideLoader"
                       @vuetable:cell-clicked="onCellClicked"
-                    ></vuetable>
+                    >
+                      <!-- Custom actions scoped slot -->
+                      <template slot="custom-actions" scope="props">
+                        <div>
+                          <button class="ui red button" @click="onClick('view-item', props.rowData)"><i class="zoom icon"></i></button>
+                          <button class="ui blue button" @click="onClick('edit-item', props.rowData)"><i class="edit icon"></i></button>
+                          <button class="ui green button" @click="onClick('delete-item', props.rowData)"><i class="delete icon"></i></button>
+                        </div>
+                      </template>
+                    </vuetable>
                     <div class="vuetable-pagination ui bottom attached segment grid">
                       <vuetable-pagination-info ref="paginationInfo"
                         :info-template="paginationInfoTemplate"

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -69,6 +69,11 @@
                   <slot :name="extractArgs(field.name)" :row-data="item" :row-index="index"></slot>
                 </td>
               </template>
+              <template v-else-if="typeof $scopedSlots[field.name] !== 'undefined'">
+                <td>
+                  <slot :name="field.name" :field="field" :row-data="item" :row-index="index"></slot>
+                </td>
+              </template>
               <template v-else>
                 <td v-if="hasCallback(field)" :class="field.dataClass"
                   @click="onCellClicked(item, field, $event)"

--- a/src/main.js
+++ b/src/main.js
@@ -6,27 +6,27 @@ import VuetablePaginationInfo from './components/VuetablePaginationInfo.vue'
 
 let E_SERVER_ERROR = 'Error communicating with the server'
 
-Vue.component('custom-actions', {
-  template: [
-    '<div>',
-      '<button class="ui red button" @click="onClick(\'view-item\', rowData)"><i class="zoom icon"></i></button>',
-      '<button class="ui blue button" @click="onClick(\'edit-item\', rowData)"><i class="edit icon"></i></button>',
-      '<button class="ui green button" @click="onClick(\'delete-item\', rowData)"><i class="delete icon"></i></button>',
-    '</div>'
-  ].join(''),
-  props: {
-    rowData: {
-      type: Object,
-      required: true
-    }
-  },
-  methods: {
-    onClick: function(action, data) {
-      console.log('actions: on-click', data.name)
-      sweetAlert(action, data.name)
-    },
-  }
-})
+// Vue.component('custom-actions', {
+//   template: [
+//     '<div>',
+//       '<button class="ui red button" @click="onClick(\'view-item\', rowData)"><i class="zoom icon"></i></button>',
+//       '<button class="ui blue button" @click="onClick(\'edit-item\', rowData)"><i class="edit icon"></i></button>',
+//       '<button class="ui green button" @click="onClick(\'delete-item\', rowData)"><i class="delete icon"></i></button>',
+//     '</div>'
+//   ].join(''),
+//   props: {
+//     rowData: {
+//       type: Object,
+//       required: true
+//     }
+//   },
+//   methods: {
+//     onClick: function(action, data) {
+//       console.log('actions: on-click', data.name)
+//       sweetAlert(action, data.name)
+//     },
+//   }
+// })
 
 Vue.component('my-detail-row', {
   template: [
@@ -109,9 +109,10 @@ let tableColumns = [
     callback: 'gender'
   },
   {
-    name: '__component:custom-actions',
+    name: 'custom-actions',
+    title: '',
     dataClass: 'center aligned'
-  }
+  },
 ]
 
 let vm = new Vue({
@@ -264,6 +265,10 @@ let vm = new Vue({
       if (field.name !== '__actions') {
         this.$refs.vuetable.toggleDetailRow(data.id)
       }
+    },
+    onClick: function(action, data) {
+      console.log('actions: on-click', data.name)
+      sweetAlert(action, data.name)
     },
     onCellDoubleClicked (data, field, event) {
       console.log('cellDoubleClicked:', field.name)


### PR DESCRIPTION
This feature removes the need for the `__slot` special field. Simply by creating a scoped slot template where the slot attribute matches the name of the field, it will be used as the output of that field.

Here is condensed version of what it looks like adapted from the changes I made to the demo:

```html
<vuetable ref="vuetable"
  api-url="http://vuetable.ratiw.net/api/users"
  :fields="fields"
>
  <!-- Custom actions scoped slot -->
  <template slot="custom-actions" scope="props">
    <div>
      <button class="ui red button" @click="onClick('view-item', props.rowData)"><i class="zoom icon"></i></button>
      <button class="ui blue button" @click="onClick('edit-item', props.rowData)"><i class="edit icon"></i></button>
      <button class="ui green button" @click="onClick('delete-item', props.rowData)"><i class="delete icon"></i></button>
    </div>
  </template>
</vuetable>
```

```javascript
let vm = new Vue({
  data: {
    fields: {
      // other fields...
      {
        name: 'custom-actions',
        title: '',
        dataClass: 'center aligned'
      },
    },
  },
  methods: {
    // other methods...
    onClick: function(action, data) {
      console.log('actions: on-click', data.name)
      sweetAlert(action, data.name)
    }
  }
})
```

Ideally, this could probably use a little more clean-up, but I figured I would get this out so you could try it out for yourself. Also, I have only tested a couple different scenarios with this, but I think it could replace the '__component' special field too, as you could just embed the component inside the scoped slot.

Hope you like it!