### PR TITLE
Fix for browserify - closes #19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,26 @@
 {
   "name": "vuetable-2",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A Vue.js 2.0 component for data table",
   "license": "MIT",
   "author": "Rati Wannapanop <rati.wannapanop@gmail.com>",
   "private": false,
+  "browser": {
+    "vue": "vue/dist/vue.common"
+  },
+  "browserify": {
+    "transform": [
+      "babelify",
+      [
+        "vueify",
+        {
+          "_flags": {
+            "debug": true
+          }
+        }
+      ]
+    ]
+  },
   "scripts": {
     "dev": "node build/dev-server.js",
     "build": "node build/build.js",
@@ -25,6 +41,7 @@
     "babel-preset-stage-2": "^6.0.0",
     "babel-register": "^6.0.0",
     "babel-runtime": "^6.0.0",
+    "babelify": "^7.3.0",
     "chai": "^3.5.0",
     "chromedriver": "^2.21.2",
     "connect-history-api-fallback": "^1.1.0",
@@ -62,6 +79,7 @@
     "vue-html-loader": "1.2.3",
     "vue-loader": "8.5.2",
     "vue-style-loader": "1.0.0",
+    "vueify": "^9.4.1",
     "webpack": "^1.12.2",
     "webpack-dev-middleware": "^1.4.0",
     "webpack-hot-middleware": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "license": "MIT",
   "author": "Rati Wannapanop <rati.wannapanop@gmail.com>",
   "private": false,
-  "browser": {
-    "vue": "vue/dist/vue.common"
-  },
   "browserify": {
     "transform": [
       "babelify",


### PR DESCRIPTION
Was able to require in items with browserify using the format:
```javascript
        components: {
            vuetable: require('vuetable-2/src/components/Vuetable.vue'),
            vuetablepagination: require('vuetable-2/src/components/VuetablePagination.vue'),
            vuetablepaginationinfo: require('vuetable-2/src/components/VuetablePaginationInfo.vue')
        },
```
Missing piece seemed to be defining the transforms used by this npm in the package.json