### PR TITLE
Reactive api url configurable

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -136,6 +136,10 @@ export default {
           return ['get', 'post'].indexOf(value) > -1
         }
     },
+    reactiveApiUrl: {
+        type: Boolean,
+        default: true
+    },
     apiMode: {
       type: Boolean,
       default: true
@@ -874,7 +878,7 @@ export default {
       }
     },
     'apiUrl': function (newVal, oldVal) {
-      if(newVal !== oldVal)
+      if(this.reactiveApiUrl && newVal !== oldVal)
         this.refresh()
     }
   },

--- a/test/unit/specs/Vuetable.spec.js
+++ b/test/unit/specs/Vuetable.spec.js
@@ -17,7 +17,7 @@ describe('data requests', () => {
 
   it('should loadData() to the given api when mounted', () => {
     const vm = new Vue({
-      template: '<vuetable :silent="true" :fields="columns" api-url="http://example.com/api/test"></vuetable>',
+      template: '<vuetable :silent="true" :fields="columns" api-url="http://example.com/api/test/loadOnMount"></vuetable>',
       components: {'vuetable': VuetableWithMocks },
       data: {
         columns: [
@@ -26,12 +26,12 @@ describe('data requests', () => {
       }
     }).$mount()
 
-    expect(AxiosGetStub).to.have.been.calledWith('http://example.com/api/test', {params: {page: 1, per_page: 10, sort: '' }})
+    expect(AxiosGetStub).to.have.been.calledWith('http://example.com/api/test/loadOnMount', {params: {page: 1, per_page: 10, sort: '' }})
   })
 
   it('should not loadData() when load-on-start set to false', () => {
     const vm = new Vue({
-      template: '<vuetable ref="vuetable" :load-on-start="false" :fields="columns" api-url="http://example.com/api/test" :silent="true"></vuetable>',
+      template: '<vuetable ref="vuetable" :load-on-start="false" :fields="columns" api-url="http://example.com/api/test/noLoadOnMount" :silent="true"></vuetable>',
       components: {'vuetable': VuetableWithMocks},
       data: {
         columns: [

--- a/test/unit/specs/Vuetable.spec.js
+++ b/test/unit/specs/Vuetable.spec.js
@@ -73,6 +73,31 @@ describe('data requests', () => {
       expect(AxiosGetStub).to.be.calledWith('http://example.com/api/test/apiUrlChange', {params: {page: 1, per_page: 10, sort: ''}})
     }).then(done, done)
   })
+
+  it('should not refresh the data if the api-url changes and reactive api url is disabled', done => {
+    const vm = new Vue({
+      template: '<vuetable ref="vuetable" :reactive-api-url="false" :load-on-start="false" :fields="columns" :api-url="apiUrl" :silent="true"></vuetable>',
+      components: {'vuetable': VuetableWithMocks},
+      data: {
+       columns: [
+         'name', 'description'
+       ],
+       apiUrl: 'http://example.com/api/test'
+      }
+      }).$mount()
+
+    let refreshSpy = sandbox.spy(vm.$refs.vuetable, 'refresh')
+
+    const newApiUrl = 'http://example.com/api/test/noReactiveApiUrl';
+    vm.apiUrl = newApiUrl
+
+    vm.$nextTick().then(() => {
+      expect(refreshSpy).to.not.have.been.called
+      expect(vm.$refs.vuetable.apiUrl).to.equal(newApiUrl)
+      expect(AxiosGetStub).to.not.have.been.calledWith('http://example.com/api/test/noReactiveApiUrl', {params: {page: 1, per_page: 10, sort: ''}})
+    })
+      .then(done, done)
+  })
 })
 
 /**

--- a/test/unit/specs/Vuetable.spec.js
+++ b/test/unit/specs/Vuetable.spec.js
@@ -2,6 +2,8 @@ import Vue from 'vue'
 import Vuetable from '../../../src/components/Vuetable.vue'
 const VuetableInjector = require('!!vue-loader?inject!../../../src/components/Vuetable')
 
+let sandbox = sinon.sandbox.create()
+
 describe('data requests', () => {
   let VuetableWithMocks
   let AxiosGetStub
@@ -13,6 +15,11 @@ describe('data requests', () => {
          get: AxiosGetStub
        }
      })
+
+  })
+
+  afterEach(function() {
+    sandbox.restore()
   })
 
   it('should loadData() to the given api when mounted', () => {
@@ -56,14 +63,13 @@ describe('data requests', () => {
       }
     }).$mount()
 
+    let refreshSpy = sandbox.spy(vm.$refs.vuetable, 'refresh')
+
     const newApiUrl = 'http://example.com/api/test/apiUrlChange';
     vm.apiUrl = newApiUrl
 
-    vm.$refs.vuetable.currentPage = 42 // To make sure we refresh, i.e. currentPage is set to 1
-
     vm.$nextTick().then(() => {
-      expect(vm.$refs.vuetable.currentPage).to.equal(1)
-      expect(vm.$refs.vuetable.apiUrl).to.equal(newApiUrl)
+      expect(refreshSpy).to.have.been.called
       expect(AxiosGetStub).to.be.calledWith('http://example.com/api/test/apiUrlChange', {params: {page: 1, per_page: 10, sort: ''}})
     }).then(done, done)
   })

--- a/test/unit/specs/Vuetable.spec.js
+++ b/test/unit/specs/Vuetable.spec.js
@@ -44,8 +44,29 @@ describe('data requests', () => {
     expect(AxiosGetStub).to.not.have.been.called
   })
 
+  it('should refresh the data if the api-url changes', done => {
+    const vm = new Vue({
+      template: '<vuetable ref="vuetable" :load-on-start="false" :fields="columns" :api-url="apiUrl" :silent="true"></vuetable>',
+      components: {'vuetable': VuetableWithMocks},
+      data: {
+        columns: [
+          'name', 'description'
+        ],
+        apiUrl: 'http://example.com/api/test'
+      }
+    }).$mount()
 
+    const newApiUrl = 'http://example.com/api/test/apiUrlChange';
+    vm.apiUrl = newApiUrl
 
+    vm.$refs.vuetable.currentPage = 42 // To make sure we refresh, i.e. currentPage is set to 1
+
+    vm.$nextTick().then(() => {
+      expect(vm.$refs.vuetable.currentPage).to.equal(1)
+      expect(vm.$refs.vuetable.apiUrl).to.equal(newApiUrl)
+      expect(AxiosGetStub).to.be.calledWith('http://example.com/api/test/apiUrlChange', {params: {page: 1, per_page: 10, sort: ''}})
+    }).then(done, done)
+  })
 })
 
 /**

--- a/test/unit/specs/Vuetable.spec.js
+++ b/test/unit/specs/Vuetable.spec.js
@@ -92,7 +92,6 @@ describe('data requests', () => {
 
     vm.$nextTick().then(() => {
       expect(refreshSpy).to.not.have.been.called
-      expect(vm.$refs.vuetable.apiUrl).to.equal(newApiUrl)
       expect(AxiosGetStub).to.not.have.been.calledWith('http://example.com/api/test/noReactiveApiUrl', {params: {page: 1, per_page: 10, sort: ''}})
     })
       .then(done, done)

--- a/test/unit/specs/Vuetable.spec.js
+++ b/test/unit/specs/Vuetable.spec.js
@@ -2,11 +2,10 @@ import Vue from 'vue'
 import Vuetable from '../../../src/components/Vuetable.vue'
 const VuetableInjector = require('!!vue-loader?inject!../../../src/components/Vuetable')
 
-let sandbox = sinon.sandbox.create()
-
 describe('data requests', () => {
   let VuetableWithMocks
   let AxiosGetStub
+  let sandbox = sinon.sandbox.create()
 
   beforeEach(function() {
     AxiosGetStub = sinon.stub().resolves({data: {data: [{name: 'john', description:'foo bar'}]}});

--- a/test/unit/specs/Vuetable.spec.js
+++ b/test/unit/specs/Vuetable.spec.js
@@ -69,7 +69,7 @@ describe('data requests', () => {
 
     vm.$nextTick().then(() => {
       expect(refreshSpy).to.have.been.called
-      expect(AxiosGetStub).to.be.calledWith('http://example.com/api/test/apiUrlChange', {params: {page: 1, per_page: 10, sort: ''}})
+      expect(AxiosGetStub).to.have.been.calledWith('http://example.com/api/test/apiUrlChange', {params: {page: 1, per_page: 10, sort: ''}})
     }).then(done, done)
   })
 

--- a/test/unit/specs/Vuetable.spec.js
+++ b/test/unit/specs/Vuetable.spec.js
@@ -15,10 +15,6 @@ describe('data requests', () => {
      })
   })
 
-  afterEach(function() {
-    AxiosGetStub.reset();
-  })
-
   it('should loadData() to the given api when mounted', () => {
     const vm = new Vue({
       template: '<vuetable :silent="true" :fields="columns" api-url="http://example.com/api/test"></vuetable>',

--- a/test/unit/specs/Vuetable.spec.js
+++ b/test/unit/specs/Vuetable.spec.js
@@ -7,7 +7,7 @@ describe('data requests', () => {
   let AxiosGetStub
 
   beforeEach(function() {
-    AxiosGetStub = sinon.stub().resolves();
+    AxiosGetStub = sinon.stub().resolves({data: {data: [{name: 'john', description:'foo bar'}]}});
     VuetableWithMocks = VuetableInjector({
        'axios': {
          get: AxiosGetStub


### PR DESCRIPTION
Fixes https://github.com/ratiw/vuetable-2/issues/152

Introduces possibility to disable the reactive api-url. Per default it is enabled.
