### PR TITLE
Add current row as argument to callback

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -662,6 +662,8 @@ export default {
 
       let args = field.callback.split('|')
       let func = args.shift()
+      
+      args = args.concat(item); //Add current row as the last argument to callback
 
       if (typeof this.$parent[func] === 'function') {
         let value = this.getObjectValue(item, field.name)


### PR DESCRIPTION
This small path adds current row as a last argument to the callback function for field. So now it is posible to do some extra checks and show the value depending of other data in the row.

Example:
Row:
```Javascript
{
  transaction_id: '123456',
  amount: 100,
  direction: 'in'
}
```

Callback:
```Javascript
showAmount (value, direction, row) {
  return (row.direction == direction)
    ? value
    : '';
}
```

Fields:
```Javascript
{
  name: 'amount',
  title: 'Income',
  callback: 'showAmount|in'
},
{
  name: 'amount',
  title: 'Outgo',
  callback: 'showAmount|out'
}
```

The row added as last argument for not breaking BC