### PR TITLE
Add ability to pass data to components

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -57,7 +57,7 @@
                 </td>
                 <td v-if="extractName(field.name) === '__component'" :class="['vuetable-component', field.dataClass]">
                   <component :is="extractArgs(field.name)"
-                    :row-data="item" :row-index="index" :row-field="field.sortField"
+                    :row-data="item" :row-index="index" :row-field="field.sortField" :properties="field.properties"
                   ></component>
                 </td>
                 <td v-if="extractName(field.name) === '__slot'" :class="['vuetable-slot', field.dataClass]">
@@ -352,6 +352,7 @@ export default {
             dataClass: '',
             callback: null,
             visible: true,
+            properties: {},
           }
         } else {
           obj = {
@@ -362,6 +363,7 @@ export default {
             dataClass: (field.dataClass === undefined) ? '' : field.dataClass,
             callback: (field.callback === undefined) ? '' : field.callback,
             visible: (field.visible === undefined) ? true : field.visible,
+            properties: (field.properties === undefined) ? {} : field.properties,
           }
         }
         self.tableFields.push(obj)


### PR DESCRIPTION
This PR adds the ability to pass additional data to components per field. This can be useful when, for instance, having an action buttons components and needing to pass URLs:
```javascript
{
    name: '__component:table-actions',
    title: 'Actions',
    properties: {
        viewUrl: '/customers/{id}'
    }
}
```

But of course there can be many other reasons to pass non-row specific data to a component.