### PR TITLE
Apply a link <a href="/link_to/"></a> to a field value.

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -70,13 +70,13 @@
                 <td v-if="hasCallback(field)" :class="field.dataClass"
                   @click="onCellClicked(item, field, $event)"
                   @dblclick="onCellDoubleClicked(item, field, $event)"
-                  v-html="callCallback(field, item)"
+                  v-html="applyLink(callCallback(field, item), item, field)"
                 >
                 </td>
                 <td v-else :class="field.dataClass"
                   @click="onCellClicked(item, field, $event)"
                   @dblclick="onCellDoubleClicked(item, field, $event)"
-                  v-html="getObjectValue(item, field.name, '')"
+                  v-html="applyLink(getObjectValue(item, field.name, ''), item, field)"
                 >
                 </td>
               </template>
@@ -265,6 +265,10 @@ export default {
         return 'No Data Available'
       }
     },
+    link: {
+      type: String,
+      default: ''
+    },
   },
   data () {
     return {
@@ -328,7 +332,7 @@ export default {
       return this.minRows - this.tableData.length
     },
     isApiMode () {
-      return this.apiMode 
+      return this.apiMode
     },
     isDataMode () {
       return ! this.apiMode
@@ -363,6 +367,7 @@ export default {
             dataClass: (field.dataClass === undefined) ? '' : field.dataClass,
             callback: (field.callback === undefined) ? '' : field.callback,
             visible: (field.visible === undefined) ? true : field.visible,
+            link: field.link,
           }
         }
         self.tableFields.push(obj)
@@ -403,8 +408,8 @@ export default {
       return title
     },
     renderSequence (index) {
-      return this.tablePagination 
-        ? this.tablePagination.from + index 
+      return this.tablePagination
+        ? this.tablePagination.from + index
         : index
     },
     isSpecialField (fieldName) {
@@ -649,6 +654,17 @@ export default {
       let opacity = max - current * step
 
       return opacity
+    },
+    applyLink (value, item, field) {
+      if (field.link) {
+          let expr = /\{(.+)\}/
+          // let linkfield = /\{.+\}/g.exec(field.link)
+          let linkField = expr.exec(field.link)[1]
+          let link = field.link.replace('{' + linkField + '}', item[linkField])
+          let result = '<a href="' + link + '">' + value + '</a>'
+          return result
+      }
+      else return value
     },
     hasCallback (item) {
       return item.callback ? true : false

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -367,7 +367,7 @@ export default {
             dataClass: (field.dataClass === undefined) ? '' : field.dataClass,
             callback: (field.callback === undefined) ? '' : field.callback,
             visible: (field.visible === undefined) ? true : field.visible,
-            link: field.link,
+            link: (field.link === undefined) ? '' : field.link,
           }
         }
         self.tableFields.push(obj)
@@ -656,9 +656,8 @@ export default {
       return opacity
     },
     applyLink (value, item, field) {
-      if (field.link) {
+      if (field.link && field.link.length) {
           let expr = /\{(.+)\}/
-          // let linkfield = /\{.+\}/g.exec(field.link)
           let linkField = expr.exec(field.link)[1]
           let link = field.link.replace('{' + linkField + '}', item[linkField])
           let result = '<a href="' + link + '">' + value + '</a>'

--- a/src/main.js
+++ b/src/main.js
@@ -164,7 +164,8 @@ let tableColumns = [
   {
     name: 'name',
     title: '<i class="book icon"></i> Full Name',
-    sortField: 'name'
+    sortField: 'name',
+    link: '/this_is_the_link_to/{id}'
   },
   {
     name: 'email',
@@ -190,7 +191,8 @@ let tableColumns = [
     sortField: 'gender',
     titleClass: 'center aligned',
     dataClass: 'center aligned',
-    callback: 'gender'
+    callback: 'gender',
+    link: '/this_is_the_other_link_to/{id}'
   },
   {
     name: '__component:custom-actions',


### PR DESCRIPTION
I've added a link property to the field definition so the cell value will be embedded in a <a href"..."> </a>.
This enable easy adding links to different cells.
I use this as my table references different individual cells.

I think there are ways to do this with __slot fields, but it was to much overhead to implement this.
I also tried using the cell_clicked event, but there I was missing the necessary information in the field object.

