### PR TITLE
Allow "no sorted" Icons & add class for sorted columns & allows to cancel unfinished request

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -113,6 +113,7 @@
 </template>
 
 <script>
+console.log("HOla mnudo");
 import axios from 'axios'
 
 export default {
@@ -278,6 +279,9 @@ export default {
     }
   },
   mounted () {
+
+    console.log("Hoal muno 456")
+
     this.normalizeFields()
     this.normalizeSortOrder()
     this.$nextTick(function() {
@@ -328,7 +332,7 @@ export default {
       return this.minRows - this.tableData.length
     },
     isApiMode () {
-      return this.apiMode 
+      return this.apiMode
     },
     isDataMode () {
       return ! this.apiMode
@@ -403,8 +407,8 @@ export default {
       return title
     },
     renderSequence (index) {
-      return this.tablePagination 
-        ? this.tablePagination.from + index 
+      return this.tablePagination
+        ? this.tablePagination.from + index
         : index
     },
     isSpecialField (fieldName) {

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -113,7 +113,6 @@
 </template>
 
 <script>
-console.log("HOla mnudo");
 import axios from 'axios'
 
 export default {
@@ -209,6 +208,15 @@ export default {
         return false
       }
     },
+    /**
+     * Sometimes you want to have an icon even when is not sorted at all
+     */
+    noSortedIcon: {
+      type: Boolean,
+      default () {
+        return false
+      }
+    },
     /*
      * physical key that will trigger multi-sort option
      * possible values: 'alt', 'ctrl', 'meta', 'shift'
@@ -247,6 +255,7 @@ export default {
           loadingClass: 'loading',
           ascendingIcon: 'blue chevron up icon',
           descendingIcon: 'blue chevron down icon',
+          noSortedIcon: 'blue chevron up-down icon',
           detailRowClass: 'vuetable-detail-row',
           handleIcon: 'grey sidebar icon',
         }
@@ -279,9 +288,6 @@ export default {
     }
   },
   mounted () {
-
-    console.log("Hoal muno 456")
-
     this.normalizeFields()
     this.normalizeSortOrder()
     this.$nextTick(function() {
@@ -399,7 +405,7 @@ export default {
     renderTitle (field) {
       let title = (typeof field.title === 'undefined') ? field.name.replace('.', ' ') : field.title
 
-      if (title.length > 0 && this.isInCurrentSortGroup(field)) {
+      if (title.length > 0 || (this.isInCurrentSortGroup(field) || this.noSortedIcon)) {
         let style = `opacity:${this.sortIconOpacity(field)};position:relative;float:right`
         return title + ' ' + this.renderIconTag(['sort-icon', this.sortIcon(field)], `style="${style}"`)
       }
@@ -624,6 +630,8 @@ export default {
 
       if (i !== false) {
         cls = (this.sortOrder[i].direction == 'asc') ? this.css.ascendingIcon : this.css.descendingIcon
+      } else {
+        cls = this.css.noSortedIcon
       }
 
       return cls;

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -12,12 +12,12 @@
               </th>
               <th v-if="extractName(field.name) == '__component'"
                   @click="orderBy(field, $event)"
-                  :class="['vuetable-th-component-'+trackBy, field.titleClass, {'sortable': isSortable(field)}]"
+                  :class="['vuetable-th-component-'+trackBy, field.titleClass, {'sortable': isSortable(field), 'sorted': isInCurrentSortGroup(field)}]"
                   v-html="renderTitle(field)"
               ></th>
               <th v-if="extractName(field.name) == '__slot'"
                   @click="orderBy(field, $event)"
-                  :class="['vuetable-th-slot-'+extractArgs(field.name), field.titleClass, {'sortable': isSortable(field)}]"
+                  :class="['vuetable-th-slot-'+extractArgs(field.name), field.titleClass, {'sortable': isSortable(field), 'sorted': isInCurrentSortGroup(field)}]"
                   v-html="renderTitle(field)"
               ></th>
               <th v-if="extractName(field.name) == '__sequence'"
@@ -30,7 +30,7 @@
             <template v-else>
               <th @click="orderBy(field, $event)"
                 :id="'_' + field.name"
-                :class="['vuetable-th-'+field.name, field.titleClass,  {'sortable': isSortable(field)}]"
+                :class="['vuetable-th-'+field.name, field.titleClass,  {'sortable': isSortable(field), 'sorted': isInCurrentSortGroup(field)}]"
                 v-html="renderTitle(field)"
               ></th>
             </template>


### PR DESCRIPTION
There are three useful changes, hope you can join them to the next version or at least use as an idea:

1. Allow "no sorted" Icons
Allows to optional add a "no sorted" icon, im not sure what icon library u use but in my case i add a double (up and down) chevron icon when the column is not sorted so its more clear for the user that they can sort by clicking the title

2. Add class for sorted columns
Useful to add some kind of class for sorted columns so you can add styles for "sorted" columns and make more clear that the content is ordered by this columns

3. Cancel unfinished request when new request was sended (My favorite, please add this)
If the user quickly order a row many times, and have an unfinished request sometimes multiple "loadData" request was sended, this use much memory and in some cases the oldest request finish last so the current data is innacurate, this is more problematic with custom filters like a search input where the user type and the data was live refreshed. With this changes if the loadData funcion has a previous unfinished request it cancel it so you only have one request at a time.


PD: Sorry for the "testing" commit

