### PR TITLE
Add sorting classes to table headers

### DIFF
--- a/docs/CSS-Styling.md
+++ b/docs/CSS-Styling.md
@@ -11,6 +11,8 @@
   loadingClass: 'loading',
   ascendingIcon: 'blue chevron up icon',
   descendingIcon: 'blue chevron down icon',
+  ascendingClass: 'sorted-asc',
+  descendingClass: 'sorted-desc',
   detailRowClass: 'vuetable-detail-row',
   handleIcon: 'grey sidebar icon',
 }

--- a/docs/Vuetable-Properties.md
+++ b/docs/Vuetable-Properties.md
@@ -190,6 +190,13 @@
   
   See also: [`visibleDetailRows`](#), and [`selectedTo`](#)
 
+### # show-sort-icons
+- type: _Boolean_
+- default: `true`
+- description
+
+  Tells Vuetable whether or not icons should be added to `th` elements whenever a given column is used to sort.
+
 ### # sort-order
 - works in `api-mode` only
 - type: _Array_

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -267,6 +267,10 @@ export default {
         return 'No Data Available'
       }
     },
+    showSortIcons: {
+      type: Boolean,
+      default: true
+    }
   },
   data () {
     return {
@@ -399,7 +403,8 @@ export default {
 
       if (title.length > 0 && this.isInCurrentSortGroup(field)) {
         let style = `opacity:${this.sortIconOpacity(field)};position:relative;float:right`
-        return title + ' ' + this.renderIconTag(['sort-icon', this.sortIcon(field)], `style="${style}"`)
+        let iconTag = this.showSortIcons ? this.renderIconTag(['sort-icon', this.sortIcon(field)], `style="${style}"`) : ''
+        return title + ' ' + iconTag
       }
 
       return title

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -12,12 +12,12 @@
               </th>
               <th v-if="extractName(field.name) == '__component'"
                   @click="orderBy(field, $event)"
-                  :class="['vuetable-th-component-'+trackBy, field.titleClass, {'sortable': isSortable(field)}]"
+                  :class="['vuetable-th-component-'+trackBy, field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
                   v-html="renderTitle(field)"
               ></th>
               <th v-if="extractName(field.name) == '__slot'"
                   @click="orderBy(field, $event)"
-                  :class="['vuetable-th-slot-'+extractArgs(field.name), field.titleClass, {'sortable': isSortable(field)}]"
+                  :class="['vuetable-th-slot-'+extractArgs(field.name), field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
                   v-html="renderTitle(field)"
               ></th>
               <th v-if="extractName(field.name) == '__sequence'"
@@ -30,7 +30,7 @@
             <template v-else>
               <th @click="orderBy(field, $event)"
                 :id="'_' + field.name"
-                :class="['vuetable-th-'+field.name, field.titleClass,  {'sortable': isSortable(field)}]"
+                :class="['vuetable-th-'+field.name, field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
                 v-html="renderTitle(field)"
               ></th>
             </template>
@@ -246,6 +246,8 @@ export default {
           loadingClass: 'loading',
           ascendingIcon: 'blue chevron up icon',
           descendingIcon: 'blue chevron down icon',
+          ascendingClass: 'sorted-asc',
+          descendingClass: 'sorted-desc',
           detailRowClass: 'vuetable-detail-row',
           handleIcon: 'grey sidebar icon',
         }
@@ -613,6 +615,16 @@ export default {
         sortField: '',
         direction: 'asc'
       });
+    },
+    sortClass (field) {
+      let cls = ''
+      let i = this.currentSortOrderPosition(field)
+
+      if (i !== false) {
+        cls = (this.sortOrder[i].direction == 'asc') ? this.css.ascendingClass : this.css.descendingClass
+      }
+
+      return cls;
     },
     sortIcon (field) {
       let cls = ''


### PR DESCRIPTION
Adds a class to a `th` element whenever that column is sorted, configurable from the `css` prop. Also adds a `showSortIcons` prop to disable inserting the `icon` elements if desired. This seems like a pretty low risk solution to provide some extra flexibility for other use cases.

Likely solves #48 