### PR TITLE
Improve `api-mode = false` experience

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -985,6 +985,9 @@ export default {
     'apiUrl'  (newVal, oldVal) {
       if(this.reactiveApiUrl && newVal !== oldVal)
         this.refresh()
+    },
+    'data' (newVal, oldVal) {
+      this.setData(newVal)
     }
   },
 }

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -601,7 +601,9 @@ export default {
       }
 
       this.currentPage = 1    // reset page index
-      this.loadData()
+      if (this.apiMode) {
+        this.loadData()
+      }
     },
     multiColumnSort (field) {
       let i = this.currentSortOrderPosition(field);


### PR DESCRIPTION
This PR introduces 2 minor changes that make a big difference for data mode, especially helping with Vuex interactivity:

1. Sorting the table will no longer call `loadData()` if not in api mode. This means that clicking on a header will not wipe the data inside the table. There is the data-manager route, but that did not work for my use case. What this allows is to set `sortParams` from the parent component, pass it as a prop to `vuetable`, and then watch the `sortParams` in the parent to see any changes to the sorting. i.e. sorting can be manually accomplished in `api-mode = false` without having to use a data-manager (which means it can be async, since data-manager requires you to have a synchronous transformation).

2. The `data` prop is now reactive (well, it is watched and will refresh the table when it is changed). This allows passing an array/object into the `data` prop, and simply changing that array/object in order to update the table.

My reasoning behind these changes is to make the data mode be more friendly for Vuex. The second change in particular is very nice because `data` can simply be boud to a Vuex getter and the table will react to any Vuex state changes. The first change just provides an async mechanism to monitor the sorting so you can, for instance, fire off a Vuex action.

If this is merged, I would love to help create some documentation for the Wiki/docs that describes a basic example of using Vuex. Getting Vuex and Vuetable to play nicely without at least the second change was proving very difficult.