### PR TITLE
Fix broken MIT license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![npm](https://img.shields.io/npm/v/vuetable-2.svg)](https://www.npmjs.com/package/vuetable-2)
 [![npm](https://img.shields.io/npm/dt/vuetable-2.svg)](https://www.npmjs.com/package/vuetable-2)
-[![npm](https://img.shields.io/npm/l/vuetable-2.svg?maxAge=2592000)]()
+[![npm](https://img.shields.io/npm/l/vuetable-2.svg?maxAge=2592000)](https://github.com/ratiw/vuetable-2/blob/master/LICENSE)
 
 # Vuetable-2 - data table simplify!
 


### PR DESCRIPTION
The URL was missing from the markdown.