### PR TITLE
Pass `custom-args` to `__component` Special Field

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -83,7 +83,7 @@
                 </td>
                 <td v-if="extractName(field.name) === '__component'" :class="['vuetable-component', field.dataClass]">
                   <component :is="extractArgs(field.name)"
-                    :row-data="item" :row-index="index" :row-field="field.sortField"
+                    :row-data="item" :row-index="index" :row-field="field.sortField" :custom-args="extractCustomArgs(field.name)"
                   ></component>
                 </td>
                 <td v-if="extractName(field.name) === '__slot'" :class="['vuetable-slot', field.dataClass]">
@@ -197,7 +197,7 @@
               </td>
               <td v-if="extractName(field.name) === '__component'" :class="['vuetable-component', field.dataClass]">
                 <component :is="extractArgs(field.name)"
-                  :row-data="item" :row-index="index" :row-field="field.sortField"
+                  :row-data="item" :row-index="index" :row-field="field.sortField" :custom-args="extractCustomArgs(field.name)"
                 ></component>
               </td>
               <td v-if="extractName(field.name) === '__slot'" :class="['vuetable-slot', field.dataClass]">
@@ -788,6 +788,16 @@ export default {
     },
     extractArgs (string) {
       return string.split(':')[1]
+    },
+    extractCustomArgs (string) {
+      string = string.split(':')
+      string = string.slice(2)
+      if (string.length == 0) return ''
+      if (string.charAt(0) == '{')
+        return JSON.parse(string)
+      if (string.indexOf(',') != -1)
+        return string.split(',')
+      return string
     },
     isSortable (field) {
       return !(typeof field.sortField === 'undefined')


### PR DESCRIPTION
Created function `extractCustomArgs` Allowing for custom data to be sent to __components. The Custom Data can be string, array or object with automatic conversion.

field.name:
// String
"__component:lookupfield:ratiw"

// Array
"__component:lookupfield:ratiw,datatable,vue"

// Object
'__component:lookupfield:{"name": "ratiw", "type": "datatable"}'

// Object 2
let obj = JSON.stringify({name : 'ratiw'})
'__component:lookupfield:' + obj

would send all of these to component as `custom-args`. The function would convert this to text, array or object based on what's passed.