### PR TITLE
patch getSortOrderParam function

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -784,6 +784,31 @@ export default {
 
       return result;
     },
+    getSortOrderParam () {
+      if (!this.sortOrder || this.sortOrder.field == '') {
+        return ''
+      }
+
+      if (typeof this.$parent['getSortOrderParam'] == 'function') {
+        return this.$parent['getSortOrderParam'].call(this.$parent, this.sortOrder)
+      }
+
+      return this.getDefaultSortOrderParam()
+    },
+    getDefaultSortOrderParam () {
+      let result = '';
+
+      for (let i = 0; i < this.sortOrder.length; i++) {
+        let direction = (typeof this.sortOrder[i].direction === 'undefined')
+          ? 'asc'
+          : this.sortOrder[i].direction;
+
+        result += direction + ((i+1) < this.sortOrder.length ? ',' : '');
+      }
+
+      return result;
+    },
+	
     extractName (string) {
       return string.split(':')[0].trim()
     },

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -751,6 +751,7 @@ export default {
     getAllQueryParams () {
       let params = {}
       params[this.queryParams.sort] = this.getSortParam()
+      params[this.queryParams.order] = this.getSortOrderParam()
       params[this.queryParams.page] = this.currentPage
       params[this.queryParams.perPage] = this.perPage
 


### PR DESCRIPTION
Added function to create an 'order=' parameter similar to the getSortParam, resulting in request with

      ....sort=fieldname1, fieldname2,..&order=asc,desc,...

parameter name can also be changed in parent vue

        :query-params= "{ sort: '_sort', page: '_page', perPage: '_limit', order: '_order'}"