### PR TITLE
Add ability to pass component through field props

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -6,42 +6,51 @@
       <tr>
         <template v-for="field in tableFields">
           <template v-if="field.visible">
-            <template v-if="isSpecialField(field.name)">
-              <th v-if="extractName(field.name) == '__checkbox'"
-                  :style="{width: field.width}"
-                :class="['vuetable-th-checkbox-'+trackBy, field.titleClass]">
-                <input type="checkbox" @change="toggleAllCheckboxes(field.name, $event)"
-                  :checked="checkCheckboxesState(field.name)">
-              </th>
-              <th v-if="extractName(field.name) == '__component'"
-                  @click="orderBy(field, $event)"
+              <template v-if="isComponent(field.name)">
+                  <th @click="orderBy(field, $event)"
+                      :style="{width: field.width}"
+                      :class="['vuetable-th-component-'+trackBy, field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
+                      v-html="renderTitle(field)"
+                  ></th>
+              </template>
+              <template v-else>
+                <template v-if="isSpecialField(field.name)">
+                  <th v-if="extractName(field.name) == '__checkbox'"
+                      :style="{width: field.width}"
+                      :class="['vuetable-th-checkbox-'+trackBy, field.titleClass]">
+                      <input type="checkbox" @change="toggleAllCheckboxes(field.name, $event)"
+                      :checked="checkCheckboxesState(field.name)">
+                  </th>
+                  <th v-if="extractName(field.name) == '__component'"
+                      @click="orderBy(field, $event)"
+                      :style="{width: field.width}"
+                      :class="['vuetable-th-component-'+trackBy, field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
+                      v-html="renderTitle(field)"
+                  ></th>
+                  <th v-if="extractName(field.name) == '__slot'"
+                      @click="orderBy(field, $event)"
+                      :style="{width: field.width}"
+                      :class="['vuetable-th-slot-'+extractArgs(field.name), field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
+                      v-html="renderTitle(field)"
+                  ></th>
+                  <th v-if="extractName(field.name) == '__sequence'"
+                      :style="{width: field.width}"
+                      :class="['vuetable-th-sequence', field.titleClass || '']" v-html="renderTitle(field)">
+                  </th>
+                  <th v-if="notIn(extractName(field.name), ['__sequence', '__checkbox', '__component', '__slot'])"
+                      :style="{width: field.width}"
+                      :class="['vuetable-th-'+field.name, field.titleClass || '']" v-html="renderTitle(field)">
+                  </th>
+                </template>
+                <template v-else>
+                  <th @click="orderBy(field, $event)"
+                    :id="'_' + field.name"
                     :style="{width: field.width}"
-                  :class="['vuetable-th-component-'+trackBy, field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
-                  v-html="renderTitle(field)"
-              ></th>
-              <th v-if="extractName(field.name) == '__slot'"
-                  @click="orderBy(field, $event)"
-                    :style="{width: field.width}"
-                  :class="['vuetable-th-slot-'+extractArgs(field.name), field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
-                  v-html="renderTitle(field)"
-              ></th>
-              <th v-if="extractName(field.name) == '__sequence'"
-                    :style="{width: field.width}"
-                  :class="['vuetable-th-sequence', field.titleClass || '']" v-html="renderTitle(field)">
-              </th>
-              <th v-if="notIn(extractName(field.name), ['__sequence', '__checkbox', '__component', '__slot'])"
-                    :style="{width: field.width}"
-                  :class="['vuetable-th-'+field.name, field.titleClass || '']" v-html="renderTitle(field)">
-              </th>
-            </template>
-            <template v-else>
-              <th @click="orderBy(field, $event)"
-                :id="'_' + field.name"
-                  :style="{width: field.width}"
-                :class="['vuetable-th-'+field.name, field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
-                v-html="renderTitle(field)"
-              ></th>
-            </template>
+                    :class="['vuetable-th-'+field.name, field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
+                    v-html="renderTitle(field)"
+                  ></th>
+                </template>
+              </template>
           </template>
         </template>
         <th v-if="scrollVisible" :style="{width: scrollBarWidth}" class="vuetable-gutter-col"></th>
@@ -69,7 +78,147 @@
         <tr @dblclick="onRowDoubleClicked(item, $event)" :item-index="index" @click="onRowClicked(item, $event)" :render="onRowChanged(item)" :class="onRowClass(item, index)">
           <template v-for="field in tableFields">
             <template v-if="field.visible">
-              <template v-if="isSpecialField(field.name)">
+              <template v-if="isComponent(field.name)">
+                  <td :class="['vuetable-component', field.dataClass]">
+                    <component :is="field.name"
+                        :row-data="item" :row-index="index" :row-field="field.sortField"
+                    ></component>
+                  </td>
+              </template>
+              <template v-else>
+                <template v-if="isSpecialField(field.name)">
+                    <td v-if="extractName(field.name) == '__sequence'" :class="['vuetable-sequence', field.dataClass]"
+                    v-html="renderSequence(index)">
+                    </td>
+                    <td v-if="extractName(field.name) == '__handle'" :class="['vuetable-handle', field.dataClass]"
+                    v-html="renderIconTag(['handle-icon', css.handleIcon])"
+                    ></td>
+                    <td v-if="extractName(field.name) == '__checkbox'" :class="['vuetable-checkboxes', field.dataClass]">
+                    <input type="checkbox"
+                        @change="toggleCheckbox(item, field.name, $event)"
+                        :checked="rowSelected(item, field.name)">
+                    </td>
+                    <td v-if="extractName(field.name) === '__component'" :class="['vuetable-component', field.dataClass]">
+                    <component :is="extractArgs(field.name)"
+                        :row-data="item" :row-index="index" :row-field="field.sortField"
+                    ></component>
+                    </td>
+                    <td v-if="extractName(field.name) === '__slot'" :class="['vuetable-slot', field.dataClass]">
+                    <slot :name="extractArgs(field.name)"
+                        :row-data="item" :row-index="index" :row-field="field.sortField"
+                    ></slot>
+                    </td>
+                </template>
+                <template v-else>
+                  <td :class="field.dataClass"
+                    @click="onCellClicked(item, field, $event)"
+                    @dblclick="onCellDoubleClicked(item, field, $event)"
+                    @contextmenu="onCellRightClicked(item, field, $event)"
+                    v-html="renderNormalField(field, item)"
+                  >
+                  </td>
+                </template>
+              </template>
+            </template>
+          </template>
+        </tr>
+        <template v-if="useDetailRow">
+          <transition :name="detailRowTransition">
+            <tr v-if="isVisibleDetailRow(item[trackBy])"
+              @click="onDetailRowClick(item, $event)"
+              :class="[css.detailRowClass]"
+            >
+              <td :colspan="countVisibleFields">
+                <component :is="detailRowComponent" :row-data="item" :row-index="index"></component>
+              </td>
+            </tr>
+          </transition>
+        </template>
+      </template>
+      <template v-if="displayEmptyDataRow">
+        <tr>
+          <td :colspan="countVisibleFields" class="vuetable-empty-result">{{noDataTemplate}}</td>
+        </tr>
+      </template>
+      <template v-if="lessThanMinRows">
+        <tr v-for="i in blankRows" class="blank-row">
+          <template v-for="field in tableFields">
+            <td v-if="field.visible">&nbsp;</td>
+          </template>
+        </tr>
+      </template>
+    </tbody>
+    </table>
+  </div>
+</div>
+<table v-else :class="['vuetable', css.tableClass]"> <!-- no fixed header - regular table -->
+  <thead>
+    <tr>
+      <template v-for="field in tableFields">
+        <template v-if="field.visible">
+          <template v-if="isComponent(field.name)">
+            <th @click="orderBy(field, $event)"
+              :style="{width: field.width}"
+              :class="['vuetable-th-component-'+trackBy, field.titleClass, {'sortable': isSortable(field)}]"
+              v-html="renderTitle(field)"
+            ></th>
+          </template>
+          <template v-else>
+            <template v-if="isSpecialField(field.name)">
+              <th v-if="extractName(field.name) == '__checkbox'"
+                :style="{width: field.width}"
+                :class="['vuetable-th-checkbox-'+trackBy, field.titleClass]">
+                <input type="checkbox" @change="toggleAllCheckboxes(field.name, $event)"
+                  :checked="checkCheckboxesState(field.name)">
+              </th>
+              <th v-if="extractName(field.name) == '__component'"
+                @click="orderBy(field, $event)"
+                :style="{width: field.width}"
+                :class="['vuetable-th-component-'+trackBy, field.titleClass, {'sortable': isSortable(field)}]"
+                v-html="renderTitle(field)"
+              ></th>
+              <th v-if="extractName(field.name) == '__slot'"
+                @click="orderBy(field, $event)"
+                :style="{width: field.width}"
+                :class="['vuetable-th-slot-'+extractArgs(field.name), field.titleClass, {'sortable': isSortable(field)}]"
+                v-html="renderTitle(field)"
+              ></th>
+              <th v-if="extractName(field.name) == '__sequence'"
+                :style="{width: field.width}"
+                :class="['vuetable-th-sequence', field.titleClass || '']" v-html="renderTitle(field)">
+              </th>
+              <th v-if="notIn(extractName(field.name), ['__sequence', '__checkbox', '__component', '__slot'])"
+                :style="{width: field.width}"
+                :class="['vuetable-th-'+field.name, field.titleClass || '']" v-html="renderTitle(field)">
+              </th>
+            </template>
+            <template v-else>
+              <th @click="orderBy(field, $event)"
+                :id="'_' + field.name"
+                :style="{width: field.width}"
+                :class="['vuetable-th-'+field.name, field.titleClass,  {'sortable': isSortable(field)}]"
+                v-html="renderTitle(field)"
+              ></th>
+            </template>
+          </template>
+        </template>
+      </template>
+    </tr>
+  </thead>
+  <tbody v-cloak class="vuetable-body">
+    <template v-for="(item, index) in tableData">
+      <tr @dblclick="onRowDoubleClicked(item, $event)" :item-index="index" @click="onRowClicked(item, $event)" :render="onRowChanged(item)" :class="onRowClass(item, index)">
+        <template v-for="field in tableFields">
+          <template v-if="field.visible">
+            <template v-if="isComponent(field.name)">
+              <td :class="['vuetable-component', field.dataClass]">
+                <component :is="field.name"
+                  :row-data="item" :row-index="index" :row-field="field.sortField"
+                ></component>
+              </td>
+            </template>
+            <template v-else>
+                <template v-if="isSpecialField(field.name)">
                 <td v-if="extractName(field.name) == '__sequence'" :class="['vuetable-sequence', field.dataClass]"
                   v-html="renderSequence(index)">
                 </td>
@@ -91,137 +240,23 @@
                     :row-data="item" :row-index="index" :row-field="field.sortField"
                   ></slot>
                 </td>
-              </template>
-              <template v-else>
-                <td :class="field.dataClass"
-                  @click="onCellClicked(item, field, $event)"
-                  @dblclick="onCellDoubleClicked(item, field, $event)"
-                  @contextmenu="onCellRightClicked(item, field, $event)"
-                  v-html="renderNormalField(field, item)"
-                >
-                </td>
-                  </template>
                 </template>
-              </template>
-            </tr>
-            <template v-if="useDetailRow">
-              <transition :name="detailRowTransition">
-                <tr v-if="isVisibleDetailRow(item[trackBy])"
-                  @click="onDetailRowClick(item, $event)"
-                  :class="[css.detailRowClass]"
-                >
-                    <td :colspan="countVisibleFields">
-                      <component :is="detailRowComponent" :row-data="item" :row-index="index"></component>
-                    </td>
-                </tr>
-              </transition>
-            </template>
-          </template>
-          <template v-if="displayEmptyDataRow">
-            <tr>
-              <td :colspan="countVisibleFields" class="vuetable-empty-result">{{noDataTemplate}}</td>
-            </tr>
-          </template>
-          <template v-if="lessThanMinRows">
-            <tr v-for="i in blankRows" class="blank-row">
-              <template v-for="field in tableFields">
-                <td v-if="field.visible">&nbsp;</td>
-              </template>
-            </tr>
-          </template>
-        </tbody>
-      </table>
-    </div>
-  </div>
-</div>
-<table v-else :class="['vuetable', css.tableClass]"> <!-- no fixed header - regular table -->
-  <thead>
-    <tr>
-      <template v-for="field in tableFields">
-        <template v-if="field.visible">
-          <template v-if="isSpecialField(field.name)">
-            <th v-if="extractName(field.name) == '__checkbox'"
-              :style="{width: field.width}"
-              :class="['vuetable-th-checkbox-'+trackBy, field.titleClass]">
-              <input type="checkbox" @change="toggleAllCheckboxes(field.name, $event)"
-                :checked="checkCheckboxesState(field.name)">
-            </th>
-            <th v-if="extractName(field.name) == '__component'"
-                @click="orderBy(field, $event)"
-                :style="{width: field.width}"
-                :class="['vuetable-th-component-'+trackBy, field.titleClass, {'sortable': isSortable(field)}]"
-                v-html="renderTitle(field)"
-            ></th>
-            <th v-if="extractName(field.name) == '__slot'"
-                @click="orderBy(field, $event)"
-                :style="{width: field.width}"
-                :class="['vuetable-th-slot-'+extractArgs(field.name), field.titleClass, {'sortable': isSortable(field)}]"
-                v-html="renderTitle(field)"
-            ></th>
-            <th v-if="extractName(field.name) == '__sequence'"
-                :style="{width: field.width}"
-                :class="['vuetable-th-sequence', field.titleClass || '']" v-html="renderTitle(field)">
-            </th>
-            <th v-if="notIn(extractName(field.name), ['__sequence', '__checkbox', '__component', '__slot'])"
-                :style="{width: field.width}"
-                :class="['vuetable-th-'+field.name, field.titleClass || '']" v-html="renderTitle(field)">
-            </th>
-          </template>
-          <template v-else>
-            <th @click="orderBy(field, $event)"
-              :id="'_' + field.name"
-              :style="{width: field.width}"
-              :class="['vuetable-th-'+field.name, field.titleClass,  {'sortable': isSortable(field)}]"
-              v-html="renderTitle(field)"
-            ></th>
-          </template>
-        </template>
-      </template>
-    </tr>
-  </thead>
-  <tbody v-cloak class="vuetable-body">
-    <template v-for="(item, index) in tableData">
-      <tr @dblclick="onRowDoubleClicked(item, $event)" :item-index="index" @click="onRowClicked(item, $event)" :render="onRowChanged(item)" :class="onRowClass(item, index)">
-        <template v-for="field in tableFields">
-          <template v-if="field.visible">
-            <template v-if="isSpecialField(field.name)">
-              <td v-if="extractName(field.name) == '__sequence'" :class="['vuetable-sequence', field.dataClass]"
-                v-html="renderSequence(index)">
-              </td>
-              <td v-if="extractName(field.name) == '__handle'" :class="['vuetable-handle', field.dataClass]"
-                v-html="renderIconTag(['handle-icon', css.handleIcon])"
-              ></td>
-              <td v-if="extractName(field.name) == '__checkbox'" :class="['vuetable-checkboxes', field.dataClass]">
-                <input type="checkbox"
-                  @change="toggleCheckbox(item, field.name, $event)"
-                  :checked="rowSelected(item, field.name)">
-              </td>
-              <td v-if="extractName(field.name) === '__component'" :class="['vuetable-component', field.dataClass]">
-                <component :is="extractArgs(field.name)"
-                  :row-data="item" :row-index="index" :row-field="field.sortField"
-                ></component>
-              </td>
-              <td v-if="extractName(field.name) === '__slot'" :class="['vuetable-slot', field.dataClass]">
-                <slot :name="extractArgs(field.name)"
-                  :row-data="item" :row-index="index" :row-field="field.sortField"
-                ></slot>
-              </td>
-            </template>
-            <template v-else>
-              <td v-if="hasCallback(field)" :class="field.dataClass"
-                @click="onCellClicked(item, field, $event)"
-                @dblclick="onCellDoubleClicked(item, field, $event)"
-                @contextmenu="onCellRightClicked(item, field, $event)"
-                v-html="callCallback(field, item)"
-              >
-              </td>
-              <td v-else :class="field.dataClass"
-                @click="onCellClicked(item, field, $event)"
-                @dblclick="onCellDoubleClicked(item, field, $event)"
-                @contextmenu="onCellRightClicked(item, field, $event)"
-                v-html="getObjectValue(item, field.name, '')"
-              >
-              </td>
+                <template v-else>
+                  <td v-if="hasCallback(field)" :class="field.dataClass"
+                    @click="onCellClicked(item, field, $event)"
+                    @dblclick="onCellDoubleClicked(item, field, $event)"
+                    @contextmenu="onCellRightClicked(item, field, $event)"
+                    v-html="callCallback(field, item)"
+                  >
+                  </td>
+                  <td v-else :class="field.dataClass"
+                    @click="onCellClicked(item, field, $event)"
+                    @dblclick="onCellDoubleClicked(item, field, $event)"
+                    @contextmenu="onCellRightClicked(item, field, $event)"
+                    v-html="getObjectValue(item, field.name, '')"
+                  >
+                  </td>
+                </template>
               </template>
             </template>
           </template>
@@ -522,6 +557,9 @@ export default {
     }
   },
   methods: {
+    isComponent (column) {
+      return column instanceof Object
+    },
     getScrollBarWidth () {
       const outer = document.createElement('div');
       const inner = document.createElement('div');


### PR DESCRIPTION
I have always felt that having to make column components global can get out of control. On one project I ended up with about 60 global components for all the different columns that needed some sort of custom control (like a router-link). There may be a better way I am missing but it led me to this idea.

Effectively if you do not need to pass fields as json you can pass a component directly through the field name, rather then a reference to a global component. This allows the following:

```
import ColumnComponent from './ColumnComponent'
export default {
   data() {
      return {
         fields: [ { name: ColumnComponent, title: 'name', sortField: 'name' } ]
      }
   }
}
```

However I am not sure of the performance impact, based on my understanding of how it gets passed around I don't think there would be any problems, but I am just one person who somehow added an extra `</div>` somehow in `Vuetable.vue` adding this when I did not use any divs and could not figure out the problem for like an hour..... lol

Anyway I found that the tabspacing of the component was a little off, not sure if it was my editor (VisualStudio Code) or if there is some reason for it. I ended up doing some cleaning up but I feel it might be best to look at what I have done and make a more fluent implementation based on it rather then merging this PR.