### PR TITLE
Implemented custom transition classes for table rows

### DIFF
--- a/docs/Vuetable-Properties.md
+++ b/docs/Vuetable-Properties.md
@@ -10,6 +10,10 @@
 - data-total
 - [detail-row-component](#-detail-row-component)
 - [detail-row-transition](#-detail-row-transition)
+- [row-transition-enter-class](#-row-transition-enter-class)
+- [row-transition-leave-class](#-row-transition-leave-class)
+- [row-transition-enter-active-class](#-row-transition-enter-active-class)
+- [row-transition-leave-active-class](#-row-transition-leave-active-class)
 - [fields](#-fields)
 - [http-fetch](#-http-fetch)
 - [http-options](#-http-options)
@@ -369,6 +373,34 @@
 - description
 
   The CSS class to apply to detail row during transition.
+
+### # row-transition-enter-class
+- type: _String_
+- default: `''` _(empty string)_
+- description
+
+  The CSS class to apply to row during enter transition. See: https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes
+
+### # row-transition-leave-class
+- type: _String_
+- default: `''` _(empty string)_
+- description
+
+  The CSS class to apply to row during leave transition. See: https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes
+
+### # row-transition-enter-active-class
+- type: _String_
+- default: `''` _(empty string)_
+- description
+
+  The CSS class to apply to row during enter active transition. See: https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes
+
+### # row-transition-leave-active-class
+- type: _String_
+- default: `''` _(empty string)_
+- description
+
+  The CSS class to apply to row during leave active transition. See: https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes
 
 ### # no-data-template
 - type: _String_

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -70,7 +70,15 @@
           </template>
         </template>
       </colgroup>
-      <tbody v-cloak class="vuetable-body">
+      <tbody
+        v-cloak
+        class="vuetable-body"
+        is="transition-group"
+        :enter-class="rowTransitionEnterClass"
+        :leave-class="rowTransitionLeaveClass"
+        :enter-active-class="rowTransitionEnterActiveClass"
+        :leave-active-class="rowTransitionLeaveActiveClass"
+      >
         <template v-for="(item, itemIndex) in tableData">
           <tr 
             :key="itemIndex"
@@ -144,7 +152,7 @@
           </template>
         </template>
         <template v-if="displayEmptyDataRow">
-          <tr>
+          <tr :key="0">
             <td :colspan="countVisibleFields" class="vuetable-empty-result" v-html="noDataTemplate"></td>
           </tr>
         </template>
@@ -211,7 +219,15 @@
       </template>
     </tr>
   </thead>
-  <tbody v-cloak class="vuetable-body">
+  <tbody
+    v-cloak
+    class="vuetable-body"
+    is="transition-group"
+    :enter-class="rowTransitionEnterClass"
+    :leave-class="rowTransitionLeaveClass"
+    :enter-active-class="rowTransitionEnterActiveClass"
+    :leave-active-class="rowTransitionLeaveActiveClass"
+  >
     <template v-for="(item, itemIndex) in tableData">
       <tr @dblclick="onRowDoubleClicked(item, $event)" 
         :key="itemIndex"
@@ -293,7 +309,7 @@
       </template>
     </template>
     <template v-if="displayEmptyDataRow">
-      <tr>
+      <tr :key="0">
         <td :colspan="countVisibleFields" class="vuetable-empty-result" v-html="noDataTemplate"></td>
       </tr>
     </template>
@@ -436,6 +452,22 @@ export default {
       type: String,
       default: ''
     },
+    rowTransitionEnterClass: {
+      type: String,
+      default: ''
+    },
+    rowTransitionLeaveClass: {
+      type: String,
+      default: ''
+    },
+    rowTransitionEnterActiveClass: {
+      type: String,
+      default: ''
+    },
+    rowTransitionLeaveActiveClass: {
+      type: String,
+      default: ''
+    },    
     trackBy: {
       type: String,
       default: 'id'


### PR DESCRIPTION
Vuetable component now contains 4 new props which we can use to apply custom transition classes on table rows entering/leaving table.

- rowTransitionEnterClass
- rowTransitionLeaveClass
- rowTransitionEnterActiveClass
- rowTransitionLeaveActiveClass