### PR TITLE
Added perPage watch to reload table

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -1288,6 +1288,9 @@ export default {
     },
     'tableHeight' (newVal, oldVal) {
       this.fixHeader()
+    },
+    'perPage' (newVal, oldVal) {
+      this.reload();
     }
   },
 }


### PR DESCRIPTION
When use a dropdox for example to change the "perPage" number, reload the table.

Thanks for the amazing work.