### PR TITLE
Allow custom callback in reload/refresh method

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -1264,12 +1264,23 @@ export default {
         this.gotoPage(page)
       }
     },
-    reload () {
-      return this.loadData()
+    reload (success, failed) {
+      var noop = () => {}
+
+      success = success || noop
+      failed = failed || noop
+
+      return this.loadData(response => {
+        this.loadSuccess(response)
+        success(response)
+      }, error => {
+        this.loadFailed(error)
+        failed(error)
+      })
     },
     refresh () {
       this.currentPage = 1
-      return this.loadData()
+      return this.reload.apply(this, arguments)
     },
     resetData () {
       this.tableData = null

--- a/test/unit/specs/Vuetable.spec.js
+++ b/test/unit/specs/Vuetable.spec.js
@@ -98,6 +98,27 @@ describe('data requests', () => {
     })
       .then(done, done)
   })
+
+  it('should call callback if provided in refresh/reload function', done => {
+    const vm = new Vue({
+      template: '<vuetable ref="vuetable" :load-on-start="false" :fields="columns" :api-url="apiUrl" :silent="true"></vuetable>',
+      components: {'vuetable': VuetableWithMocks},
+      data: {
+        columns: [
+          'name', 'description'
+        ],
+        apiUrl: 'http://example.com/api/test'
+      }
+    }).$mount()
+
+    let callback = sinon.spy()
+    vm.$refs.vuetable.refresh(callback, callback)
+    vm.$refs.vuetable.reload(callback, callback)
+
+    vm.$nextTick().then(() => {
+      expect(callback).to.have.been.calledTwice
+    }).then(done, done)
+  })
 })
 
 /**


### PR DESCRIPTION
Issue #431

Only work if `api-mode=true`. Not sure if it is needed in `data-mode`.