### PR TITLE
Zero based pagination

### DIFF
--- a/docs/Pagination.md
+++ b/docs/Pagination.md
@@ -23,3 +23,30 @@ number of sliding pages = onEachSide * 2 +1
 It was designed to take up less space as all the pages will be put inside a dropdown for the user to select and jump to the selected page.
 
 Vuetable provides a `VautablePaginationMixin` and `VuetablePaginationInfoMixin` to help creating custom pagination component an easy task. Please see the source code as it is very straight forward, but you will need some knowledge about Vue.js.
+
+### Overriding the Page Query String Parameter
+
+You can override the page number that is requested by defining a method named `getPageParam()` in your main vue instance. 
+
+When Vuetable needs to make a request to the server, it will first check if this method is existed in its parent. If so, it will call this method, passing `currentPage` data to it, and will use whatever returned from the method as the page number to be requested from the server. Else it will just use the `currentPage` as is.
+
+This together with the `transform()` method is useful for working with APIs that provide zero-based pagination.
+
+
+```javascript
+// If the API uses zero-based pagination we can just subtract 1
+// from the page number before making a request.
+getPageParam: function(currentPage) {
+  return currentPage - 1;
+}
+
+// Then we add 1 in the transform method
+transform: function(data) {
+  return {
+    ...
+    current_page: data.page.number + 1,
+    last_page: data.page.lastPage + 1,
+    ...
+  }
+}
+```

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -812,7 +812,7 @@ export default {
       }
 
       params[this.queryParams.sort] = this.getSortParam()
-      params[this.queryParams.page] = this.currentPage
+      params[this.queryParams.page] = this.getPageParam()
       params[this.queryParams.perPage] = this.perPage
 
       return params
@@ -839,6 +839,13 @@ export default {
         result += fieldName + '|' + this.sortOrder[i].direction + ((i+1) < this.sortOrder.length ? ',' : '');
       }
       return result;
+    },
+    getPageParam () {
+      if (typeof this.$parent['getPageParam'] === 'function') {
+        return this.$parent['getPageParam'].call(this.$parent, this.currentPage)
+      }
+
+      return this.currentPage
     },
     getAppendParams (params) {
       for (let x in this.appendParams) {


### PR DESCRIPTION
Here's an alternative implementation of support for zero based pagination using a `getPageParam()` method (similar to overriding the sort param).

When the `getPageParam()` method is added to the parent component, it is called when building the query parameters for the request. It receives the `currentPage` as the parameter.
Thus one can return `currentPage - 1` when working with an API that does zero-based pagination.
For example:
```javascript
getPageParam: function(currentPage) {
  return currentPage - 1; // subtract 1 so that page 1 in view maps to page 0 on server ...
}
```
Then it follows that the transform method should be like so
```javascript
transform: function(data) {
  return {
    ...
    current_page: data.page.number + 1, // add 1 so that page 0 on server maps to page 1 in view ...
    last_page: data.page.lastPage + 1,
    ...
  }
}
```