### PR TITLE
Added ability to specify default sort direction for each field.

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -901,7 +901,7 @@ export default {
         this.sortOrder.push({
           field: field.name,
           sortField: field.sortField,
-          direction: 'asc'
+          direction: field.defSortDirection
         });
       } else { //this field is in the sort array, now we change its state
         if(this.sortOrder[i].direction === 'asc') {

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -623,6 +623,7 @@ export default {
             dataClass: '',
             callback: null,
             visible: true,
+            defSortDirection: 'asc',
           }
         } else {
           obj = {
@@ -634,6 +635,7 @@ export default {
             dataClass: (field.dataClass === undefined) ? '' : field.dataClass,
             callback: (field.callback === undefined) ? '' : field.callback,
             visible: (field.visible === undefined) ? true : field.visible,
+            defSortDirection: (field.defSortDirection === undefined || ['asc', 'desc'].indexOf(field.defSortDirection) === -1) ? 'asc' : field.defSortDirection,
           }
         }
         self.tableFields.push(obj)
@@ -748,28 +750,25 @@ export default {
       }
 
       this.$nextTick(function() {
+        this.fixHeader()
         this.fireEvent('pagination-data', this.tablePagination)
         this.fireEvent('loaded')
-        this.updateHeader()
       })
-    },
-    updateHeader() {
-      // $nextTick doesn't seem to work in all cases. This might be because 
-      // $nextTick is finished before the transition element (just my guess)
-      //
-      // the scrollHeight value does not yet changed, causing scrollVisible
-      // to remain "true", therefore, the header gutter never gets updated
-      // to reflect the display of scrollbar in the table body.
-      // setTimeout 80ms seems to work in this case.
-      setTimeout(this.fixHeader, 80)
     },
     fixHeader() {
-      this.$nextTick( () => {
-        let elem = this.$el.getElementsByClassName('vuetable-body-wrapper')[0]
-        if (elem != null) {
-          this.scrollVisible = (elem.scrollHeight > elem.clientHeight)
+      if (!this.isFixedHeader) {
+        return;
+      }
+
+      let elem = this.$el.getElementsByClassName('vuetable-body-wrapper')[0]
+      if (elem != null) {
+        if (elem.scrollHeight > elem.clientHeight) {
+          this.scrollVisible = true;
         }
-      })
+        else {
+          this.scrollVisible = false;
+        }
+      }
     },
     loadFailed (response) {
       console.error('load-error', response)
@@ -926,7 +925,7 @@ export default {
         this.sortOrder[0].direction = this.sortOrder[0].direction === 'asc' ? 'desc' : 'asc'
       } else {
         // reset sort direction
-        this.sortOrder[0].direction = 'asc'
+        this.sortOrder[0].direction = field.defSortDirection ? field.defSortDirection : 'asc'
       }
       this.sortOrder[0].field = field.name
       this.sortOrder[0].sortField = field.sortField
@@ -1142,7 +1141,6 @@ export default {
       if (!this.isVisibleDetailRow(rowId)) {
         this.visibleDetailRows.push(rowId)
       }
-      this.fixHeader()
     },
     hideDetailRow (rowId) {
       if (this.isVisibleDetailRow(rowId)) {
@@ -1150,7 +1148,6 @@ export default {
           this.visibleDetailRows.indexOf(rowId),
           1
         )
-        this.updateHeader()
       }
     },
     toggleDetailRow (rowId) {
@@ -1293,7 +1290,7 @@ export default {
     },
     'tableHeight' (newVal, oldVal) {
       this.fixHeader()
-    },
+    }
   },
 }
 </script>


### PR DESCRIPTION
With this update, setting defSortDirection to 'asc' or 'desc' when declaring a field, will set the default sort direction for the field. 
Example:
`  {
    name: 'name',
    title: '<i class="book icon"></i> Full Name',
    sortField: 'name',
    width: '150px',
    defSortDirection: 'desc'
  }`
This name field would sort Z-A upon it's first sort instead of A-Z. 
The default if defSortDirection is not set is still 'asc'.