### PR TITLE
Concurrent requests

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -489,6 +489,7 @@ export default {
       lastScrollPosition: 0,
       scrollBarWidth: '17px', //chrome default
       scrollVisible: false,
+      currentRequestId: 0,
     }
   },
   mounted () {

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -712,7 +712,7 @@ export default {
     notIn (str, arr) {
       return arr.indexOf(str) === -1
     },
-    loadData (success = this.loadSuccess, failed = this.loadFailed) {
+    loadData (success = this.loadSuccess(++this.currentRequestId), failed = this.loadFailed(this.currentRequestId)) {
       if (this.isDataMode) {
         this.callDataManager()
         return
@@ -732,27 +732,34 @@ export default {
           ? this.httpFetch(apiUrl, httpOptions)
           : axios[this.httpMethod](apiUrl, httpOptions)
     },
-    loadSuccess (response) {
-      this.fireEvent('load-success', response)
+    loadSuccess (requestId) {
+      let $this = this
+      return function (response) {
+        if (requestId !== $this.currentRequestId) {
+            return;
+          }
 
-      let body = this.transform(response.data)
+          $this.fireEvent('load-success', response)
 
-      this.tableData = this.getObjectValue(body, this.dataPath, null)
-      this.tablePagination = this.getObjectValue(body, this.paginationPath, null)
+          let body = $this.transform(response.data)
 
-      if (this.tablePagination === null) {
-        this.warn('vuetable: pagination-path "' + this.paginationPath + '" not found. '
-          + 'It looks like the data returned from the sever does not have pagination information '
-          + "or you may have set it incorrectly.\n"
-          + 'You can explicitly suppress this warning by setting pagination-path="".'
-        )
+          $this.tableData = $this.getObjectValue(body, $this.dataPath, null)
+          $this.tablePagination = $this.getObjectValue(body, $this.paginationPath, null)
+
+          if ($this.tablePagination === null) {
+            $this.warn('vuetable: pagination-path "' + $this.paginationPath + '" not found. '
+              + 'It looks like the data returned from the sever does not have pagination information '
+              + "or you may have set it incorrectly.\n"
+              + 'You can explicitly suppress this warning by setting pagination-path="".'
+            )
+          }
+
+        $this.$nextTick(function () {
+          $this.fixHeader()
+          $this.fireEvent('pagination-data', this.tablePagination)
+          $this.fireEvent('loaded')
+        })
       }
-
-      this.$nextTick(function() {
-        this.fixHeader()
-        this.fireEvent('pagination-data', this.tablePagination)
-        this.fireEvent('loaded')
-      })
     },
     fixHeader() {
       if (!this.isFixedHeader) {
@@ -769,10 +776,17 @@ export default {
         }
       }
     },
-    loadFailed (response) {
-      console.error('load-error', response)
-      this.fireEvent('load-error', response)
-      this.fireEvent('loaded')
+    loadFailed (requestId) {
+      let $this = this
+      return function (response) {
+        if (requestId !== $this.currentRequestId) {
+          return;
+        }
+
+        console.error('load-error', response)
+        $this.fireEvent('load-error', response)
+        $this.fireEvent('loaded')
+      }
     },
     transform (data) {
       let func = 'transform'


### PR DESCRIPTION
# Description

This pull request is set out to handle concurrent requests, when the table uses an api as datasource.

Each request gets assigned a number, which is then passed to the callbacks (both success and failure). The triggered callback checks if it is the latest request. If not, it terminates silently.

# How to reproduce the issue the PR solves:
## Setup
- Implement a table with an api it requests data from
- Ensure the api handles filters
- Force the api to hang for a couple of seconds on a specific filter to simulate slower loading
- Implement a toggle for the filter on the front-end

## Execution
- Set the filter to the slower loading setting
- Before it finishes loading, set the filter to the faster loading setting
- Wait for the table to load

## Original result
- The filter display will be the faster loading setting
- The data displayed will be the slower request's data.

## Expected result
- The filter display will be the faster loading setting
- The data displayed will be the faster request's data.


Thank you for your consideration,
Greg