### PR TITLE
Added header-event for field component in <vuetable-row-header>

### DIFF
--- a/src/components/VuetableRowHeader.vue
+++ b/src/components/VuetableRowHeader.vue
@@ -11,6 +11,7 @@
             :key="fieldIndex"
             :class="headerClass('vuetable-th-component', field)"
             :style="{width: field.width}"
+            @vuetable:header-event="vuetable.onHeaderEvent"
             @click="onColumnHeaderClicked(field, $event)"
           ></component>
         </template>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2631124/42924852-9341288e-8b5e-11e8-8ec9-448ca3bf0ea5.png)
Since field components have 'header-event' in default slot, I think it is reasonable that field components in VuetableRowHeader also have it, otherwise it will be difficult for customized field components to communicate with component based on Vuetable that using VuetableRowHeader.
