### PR TITLE
Remove '-dev' flag from 'npm install' command in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The original functionality still works
 ## NPM
 
 ```shell
-npm install vuetable-2 --save-dev
+npm install vuetable-2 --save
 ```
 
 ## Javascript via CDN


### PR DESCRIPTION
Hi.

I noticed in the readme.md that the install command has the --save-dev option. The -dev option is only used for dependencies that are supposed to work only in the development environment, which is not the case of vuetable-2. 