### PR TITLE
Add data-label fields option

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -1,130 +1,76 @@
 <template>
-<div v-if="isFixedHeader">
-  <div class="vuetable-head-wrapper">
-    <table :class="['vuetable', css.tableClass, css.tableHeaderClass]">
-    <thead>
-      <tr>
-        <template v-for="(field, fieldIndex) in tableFields">
-          <template v-if="field.visible">
-            <template v-if="isSpecialField(field.name)">
-              <th v-if="extractName(field.name) == '__checkbox'"
-                :key="fieldIndex"
-                :style="{width: field.width}"
-                :class="['vuetable-th-checkbox-'+trackBy, field.titleClass]"
-              >
-                <input type="checkbox" @change="toggleAllCheckboxes(field.name, $event)"
-                  :checked="checkCheckboxesState(field.name)">
-              </th>
-              <th v-if="extractName(field.name) == '__component'"
-                :key="fieldIndex"
-                :style="{width: field.width}"
-                :class="['vuetable-th-component-'+trackBy, field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
-                v-html="renderTitle(field)"
-                @click="orderBy(field, $event)"
-              ></th>
-              <th v-if="extractName(field.name) == '__slot'"
-                :key="fieldIndex"
-                :style="{width: field.width}"
-                :class="['vuetable-th-slot-'+extractArgs(field.name), field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
-                v-html="renderTitle(field)"
-                @click="orderBy(field, $event)"
-              ></th>
-              <th v-if="extractName(field.name) == '__sequence'"
-                :key="fieldIndex"
-                :style="{width: field.width}"
-                :class="['vuetable-th-sequence', field.titleClass || '']" v-html="renderTitle(field)">
-              </th>
-              <th v-if="notIn(extractName(field.name), ['__sequence', '__checkbox', '__component', '__slot'])"
-                :key="fieldIndex"
-                :style="{width: field.width}"
-                :class="['vuetable-th-'+field.name, field.titleClass || '']" v-html="renderTitle(field)">
-              </th>
+  <div :class="$_css.tableWrapper">
+    <div class="vuetable-head-wrapper" v-if="isFixedHeader">
+      <table :class="['vuetable', $_css.tableClass, $_css.tableHeaderClass]">
+        <vuetable-col-group :is-header="true"/>
+        <thead>
+          <slot name="tableHeader" :fields="tableFields">
+            <template v-for="(header, headerIndex) in headerRows">
+              <component :is="header" :key="headerIndex"
+                @vuetable:header-event="onHeaderEvent"
+              ></component>
             </template>
-            <template v-else>
-              <th @click="orderBy(field, $event)"
-                :key="fieldIndex"
-                :id="'_' + field.name"
-                :style="{width: field.width}"
-                :class="['vuetable-th-'+field.name, field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
-                v-html="renderTitle(field)"
-              ></th>
-            </template>
-          </template>
+          </slot>
+        </thead>
+      </table>
+    </div>
+
+    <div class="vuetable-body-wrapper" :class="{'fixed-header' : isFixedHeader}" :style="{height: tableHeight}">
+      <table :class="['vuetable', isFixedHeader ? 'fixed-header' : '', $_css.tableClass, $_css.tableBodyClass]">
+      <vuetable-col-group/>
+      <thead v-if="!isFixedHeader">
+      <slot name="tableHeader" :fields="tableFields">
+        <template v-for="(header, headerIndex) in headerRows">
+          <component :is="header" :key="headerIndex"
+            @vuetable:header-event="onHeaderEvent"
+          ></component>
         </template>
-        <th v-if="scrollVisible" :style="{width: scrollBarWidth}" class="vuetable-gutter-col"></th>
-      </tr>
-    </thead>
-    </table>
-  </div>
-  <div class="vuetable-body-wrapper" :style="{height: tableHeight}">
-    <table :class="['vuetable', css.tableClass, css.tableBodyClass]">
-      <colgroup>
-        <template v-for="(field, fieldIndex) in tableFields">
-          <template v-if="field.visible">
-            <col
-              :key="fieldIndex"
-              :id="'_col_' + field.name"
-              :style="{width: field.width}"
-              :class="['vuetable-th-'+field.name, field.titleClass]"
-            />
-          </template>
-        </template>
-      </colgroup>
+      </slot>
+      </thead>
+      <tfoot>
+        <slot name="tableFooter" :fields="tableFields"></slot>
+      </tfoot>
       <tbody v-cloak class="vuetable-body">
         <template v-for="(item, itemIndex) in tableData">
-          <tr 
+          <tr :item-index="itemIndex"
             :key="itemIndex"
-            :item-index="itemIndex" 
-            :render="onRowChanged(item)" 
             :class="onRowClass(item, itemIndex)"
-            @click="onRowClicked(item, $event)" 
-            @dblclick="onRowDoubleClicked(item, $event)" 
+            @click="onRowClicked(item, itemIndex, $event)"
+            @dblclick="onRowDoubleClicked(item, itemIndex, $event)"
+            @mouseover="onMouseOver(item, itemIndex, $event)"
           >
             <template v-for="(field, fieldIndex) in tableFields">
               <template v-if="field.visible">
-                <template v-if="isSpecialField(field.name)">
-                  <td v-if="extractName(field.name) == '__sequence'" 
+                <template v-if="isFieldComponent(field.name)">
+                  <component :is="field.name"
                     :key="fieldIndex"
-                    :class="['vuetable-sequence', field.dataClass]"
-                    v-html="renderSequence(itemIndex)">
-                  </td>
-                  <td v-if="extractName(field.name) == '__handle'" 
+                    :row-data="item" :row-index="itemIndex" :row-field="field"
+                    :vuetable="vuetable"
+                    :class="bodyClass('vuetable-component', field)"
+                    :style="{width: field.width}"
+                    @vuetable:field-event="onFieldEvent"
+                  ></component>
+                </template>
+                <template v-else-if="isFieldSlot(field.name)">
+                  <td :class="bodyClass('vuetable-slot', field)"
+                    :data-label="field.dataLabel || field.title"
                     :key="fieldIndex"
-                    :class="['vuetable-handle', field.dataClass]"
-                    v-html="renderIconTag(['handle-icon', css.handleIcon])"
-                  ></td>
-                  <td v-if="extractName(field.name) == '__checkbox'" 
-                    :key="fieldIndex"
-                    :class="['vuetable-checkboxes', field.dataClass]"
+                    :style="{width: field.width}"
                   >
-                    <input type="checkbox"
-                      @change="toggleCheckbox(item, field.name, $event)"
-                      :checked="rowSelected(item, field.name)">
-                  </td>
-                  <td v-if="extractName(field.name) === '__component'" 
-                    :key="fieldIndex"
-                    :class="['vuetable-component', field.dataClass]"
-                  >
-                    <component :is="extractArgs(field.name)"
-                      :row-data="item" :row-index="itemIndex" :row-field="field.sortField"
-                    ></component>
-                  </td>
-                  <td v-if="extractName(field.name) === '__slot'" 
-                    :key="fieldIndex"
-                    :class="['vuetable-slot', field.dataClass]"
-                  >
-                    <slot :name="extractArgs(field.name)"
-                      :row-data="item" :row-index="itemIndex" :row-field="field.sortField"
+                    <slot :name="field.name"
+                      :row-data="item" :row-index="itemIndex" :row-field="field"
                     ></slot>
                   </td>
                 </template>
                 <template v-else>
-                  <td :class="field.dataClass"
+                  <td :class="bodyClass('vuetable-td-'+field.name, field)"
+                    :data-label="field.dataLabel || field.title"
                     :key="fieldIndex"
+                    :style="{width: field.width}"
                     v-html="renderNormalField(field, item)"
-                    @click="onCellClicked(item, field, $event)"
-                    @dblclick="onCellDoubleClicked(item, field, $event)"
-                    @contextmenu="onCellRightClicked(item, field, $event)"
+                    @click="onCellClicked(item, itemIndex, field, $event)"
+                    @dblclick="onCellDoubleClicked(item, itemIndex, field, $event)"
+                    @contextmenu="onCellRightClicked(item, itemIndex, field, $event)"
                   ></td>
                 </template>
               </template>
@@ -133,11 +79,15 @@
           <template v-if="useDetailRow">
             <transition :name="detailRowTransition" :key="itemIndex">
               <tr v-if="isVisibleDetailRow(item[trackBy])"
-                :class="[css.detailRowClass]"
-                @click="onDetailRowClick(item, $event)"
+                @click="onDetailRowClick(item, itemIndex, $event)"
+                :class="onDetailRowClass(item, itemIndex)"
               >
                 <td :colspan="countVisibleFields">
-                  <component :is="detailRowComponent" :row-data="item" :row-index="itemIndex"></component>
+                  <component :is="detailRowComponent"
+                    :row-data="item"
+                    :row-index="itemIndex"
+                    :options="detailRowOptions"
+                  ></component>
                 </td>
               </tr>
             </transition>
@@ -145,7 +95,10 @@
         </template>
         <template v-if="displayEmptyDataRow">
           <tr>
-            <td :colspan="countVisibleFields" class="vuetable-empty-result" v-html="noDataTemplate"></td>
+            <td :colspan="countVisibleFields"
+              class="vuetable-empty-result"
+              v-html="noDataTemplate"
+            ></td>
           </tr>
         </template>
         <template v-if="lessThanMinRows">
@@ -156,162 +109,25 @@
           </tr>
         </template>
       </tbody>
-    </table>
+      </table>
+    </div>
   </div>
-</div>
-<table v-else :class="['vuetable', css.tableClass]"> <!-- no fixed header - regular table -->
-  <thead>
-    <tr>
-      <template v-for="(field, fieldIndex) in tableFields">
-        <template v-if="field.visible">
-          <template v-if="isSpecialField(field.name)">
-            <th v-if="extractName(field.name) == '__checkbox'"
-              :key="fieldIndex"
-              :style="{width: field.width}"
-              :class="['vuetable-th-checkbox-'+trackBy, field.titleClass]"
-            >
-              <input type="checkbox" @change="toggleAllCheckboxes(field.name, $event)"
-                :checked="checkCheckboxesState(field.name)">
-            </th>
-            <th v-if="extractName(field.name) == '__component'"
-              :key="fieldIndex"
-              :style="{width: field.width}"
-              :class="['vuetable-th-component-'+trackBy, field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
-              v-html="renderTitle(field)"
-              @click="orderBy(field, $event)"
-            ></th>
-            <th v-if="extractName(field.name) == '__slot'"
-              :key="fieldIndex"
-              :style="{width: field.width}"
-              :class="['vuetable-th-slot-'+extractArgs(field.name), field.titleClass, sortClass(field), {'sortable': isSortable(field)}]"
-              v-html="renderTitle(field)"
-              @click="orderBy(field, $event)"
-            ></th>
-            <th v-if="extractName(field.name) == '__sequence'"
-              :key="fieldIndex"
-              :style="{width: field.width}"
-              :class="['vuetable-th-sequence', field.titleClass || '', sortClass(field)]" v-html="renderTitle(field)"
-            ></th>
-            <th v-if="notIn(extractName(field.name), ['__sequence', '__checkbox', '__component', '__slot'])"
-              :key="fieldIndex"
-              :style="{width: field.width}"
-              :class="['vuetable-th-'+field.name, field.titleClass || '', sortClass(field)]" v-html="renderTitle(field)"
-            ></th>
-          </template>
-          <template v-else>
-            <th @click="orderBy(field, $event)"
-              :key="fieldIndex"
-              :id="'_' + field.name"
-              :style="{width: field.width}"
-              :class="['vuetable-th-'+field.name, field.titleClass, sortClass(field),  {'sortable': isSortable(field)}]"
-              v-html="renderTitle(field)"
-            ></th>
-          </template>
-        </template>
-      </template>
-    </tr>
-  </thead>
-  <tbody v-cloak class="vuetable-body">
-    <template v-for="(item, itemIndex) in tableData">
-      <tr @dblclick="onRowDoubleClicked(item, $event)" 
-        :key="itemIndex"
-        :item-index="itemIndex" 
-        :render="onRowChanged(item)" 
-        :class="onRowClass(item, itemIndex)"
-        @click="onRowClicked(item, $event)" 
-      >
-        <template v-for="(field, fieldIndex) in tableFields">
-          <template v-if="field.visible">
-            <template v-if="isSpecialField(field.name)">
-              <td v-if="extractName(field.name) == '__sequence'" 
-                :key="fieldIndex"
-                :class="['vuetable-sequence', field.dataClass]"
-                v-html="renderSequence(itemIndex)"
-              ></td>
-              <td v-if="extractName(field.name) == '__handle'" 
-                :key="fieldIndex"
-                :class="['vuetable-handle', field.dataClass]"
-                v-html="renderIconTag(['handle-icon', css.handleIcon])"
-              ></td>
-              <td v-if="extractName(field.name) == '__checkbox'" 
-                :key="fieldIndex"
-                :class="['vuetable-checkboxes', field.dataClass]"
-              >
-                <input type="checkbox"
-                  @change="toggleCheckbox(item, field.name, $event)"
-                  :checked="rowSelected(item, field.name)">
-              </td>
-              <td v-if="extractName(field.name) === '__component'" 
-                :key="fieldIndex"
-                :class="['vuetable-component', field.dataClass]"
-              >
-                <component :is="extractArgs(field.name)"
-                  :row-data="item" :row-index="itemIndex" :row-field="field.sortField"
-                ></component>
-              </td>
-              <td v-if="extractName(field.name) === '__slot'" 
-                :key="fieldIndex"
-                :class="['vuetable-slot', field.dataClass]"
-              >
-                <slot :name="extractArgs(field.name)"
-                  :row-data="item" :row-index="itemIndex" :row-field="field.sortField"
-                ></slot>
-              </td>
-            </template>
-            <template v-else>
-              <td v-if="hasCallback(field)" 
-                :key="fieldIndex"
-                :class="field.dataClass"
-                v-html="callCallback(field, item)"
-                @click="onCellClicked(item, field, $event)"
-                @dblclick="onCellDoubleClicked(item, field, $event)"
-                @contextmenu="onCellRightClicked(item, field, $event)"
-              ></td>
-              <td v-else 
-                :key="fieldIndex"
-                :class="field.dataClass"
-                v-html="getObjectValue(item, field.name, '')"
-                @click="onCellClicked(item, field, $event)"
-                @dblclick="onCellDoubleClicked(item, field, $event)"
-                @contextmenu="onCellRightClicked(item, field, $event)"
-              ></td>
-            </template>
-          </template>
-        </template>
-      </tr>
-      <template v-if="useDetailRow">
-        <transition :name="detailRowTransition" :key="itemIndex">
-          <tr v-if="isVisibleDetailRow(item[trackBy])"
-            :class="[css.detailRowClass]"
-            @click="onDetailRowClick(item, $event)"
-          >
-            <td :colspan="countVisibleFields">
-              <component :is="detailRowComponent" :row-data="item" :row-index="itemIndex"></component>
-            </td>
-          </tr>
-        </transition>
-      </template>
-    </template>
-    <template v-if="displayEmptyDataRow">
-      <tr>
-        <td :colspan="countVisibleFields" class="vuetable-empty-result" v-html="noDataTemplate"></td>
-      </tr>
-    </template>
-    <template v-if="lessThanMinRows">
-      <tr v-for="i in blankRows" class="blank-row" :key="i">
-        <template v-for="(field, fieldIndex) in tableFields">
-          <td v-if="field.visible" :key="fieldIndex">&nbsp;</td>
-        </template>
-      </tr>
-    </template>
-  </tbody>
-</table>
 </template>
 
 <script>
 import axios from 'axios'
+import VuetableRowHeader from './VuetableRowHeader'
+import VuetableColGroup from './VuetableColGroup'
+import CssSemanticUI from './VuetableCssSemanticUI.js'
 
 export default {
+  name: 'Vuetable',
+
+  components: {
+    VuetableRowHeader,
+    VuetableColGroup,
+  },
+
   props: {
     fields: {
       type: Array,
@@ -322,19 +138,19 @@ export default {
       default: true
     },
     apiUrl: {
-        type: String,
-        default: ''
+      type: String,
+      default: ''
     },
     httpMethod: {
-        type: String,
-        default: 'get',
-        validator: (value) => {
-          return ['get', 'post'].indexOf(value) > -1
-        }
+      type: String,
+      default: 'get',
+      validator: (value) => {
+        return ['get', 'post'].indexOf(value) > -1
+      }
     },
     reactiveApiUrl: {
-        type: Boolean,
-        default: true
+      type: Boolean,
+      default: true
     },
     apiMode: {
       type: Boolean,
@@ -344,21 +160,17 @@ export default {
       type: [Array, Object],
       default: null
     },
-    dataTotal: {
-      type: Number,
-      default: 0
-    },
     dataManager: {
       type: Function,
       default: null
     },
     dataPath: {
-        type: String,
-        default: 'data'
+      type: String,
+      default: 'data'
     },
     paginationPath: {
-        type: [String],
-        default: 'links.pagination'
+      type: String,
+      default: 'links.pagination'
     },
     queryParams: {
       type: [Object, Function],
@@ -390,7 +202,17 @@ export default {
         type: Number,
         default: 10
     },
+    /**
+     * Page that should be displayed when the table is first displayed
+     */
     initialPage: {
+      type: Number,
+      default: 1
+    },
+    /**
+     * First page number. Set this prop to 0 for zero based pagination
+     */
+    firstPage: {
       type: Number,
       default: 1
     },
@@ -402,9 +224,7 @@ export default {
     },
     multiSort: {
       type: Boolean,
-      default () {
-        return false
-      }
+      default: false
     },
     tableHeight: {
       type: String,
@@ -419,22 +239,27 @@ export default {
       type: String,
       default: 'alt'
     },
-    /* deprecated */
-    rowClassCallback: {
-      type: [String, Function],
-      default: ''
-    },
     rowClass: {
       type: [String, Function],
       default: ''
     },
     detailRowComponent: {
-      type: String,
+      type: [String, Object],
       default: ''
     },
     detailRowTransition: {
       type: String,
       default: ''
+    },
+    detailRowClass: {
+      type: [String, Function],
+      default: 'vuetable-detail-row'
+    },
+    detailRowOptions: {
+      type: Object,
+      default() {
+        return {}
+      }
     },
     trackBy: {
       type: String,
@@ -443,19 +268,7 @@ export default {
     css: {
       type: Object,
       default () {
-        return {
-          tableClass: 'ui blue selectable celled stackable attached table',
-          loadingClass: 'loading',
-          ascendingIcon: 'blue chevron up icon',
-          descendingIcon: 'blue chevron down icon',
-          ascendingClass: 'sorted-asc',
-          descendingClass: 'sorted-desc',
-          sortableIcon: '',
-          detailRowClass: 'vuetable-detail-row',
-          handleIcon: 'grey sidebar icon',
-          tableBodyClass: 'vuetable-semantic-no-top vuetable-fixed-layout',
-          tableHeaderClass: 'vuetable-fixed-layout'
-        }
+        return {}
       }
     },
     minRows: {
@@ -475,11 +288,37 @@ export default {
     showSortIcons: {
       type: Boolean,
       default: true
+    },
+    headerRows: {
+      type: Array,
+      default() {
+        return ['VuetableRowHeader']
+      }
+    },
+    transform: {
+      type: Function,
+      default: null
+    },
+    sortParams: {
+      type: Function,
+      default: null
+    },
+    fieldPrefix: {
+      type: String,
+      default() {
+        return 'vuetable-field-'
+      }
+    },
+    eventPrefix: {
+      type: String,
+      default() {
+        return 'vuetable:'
+      }
     }
   },
+
   data () {
     return {
-      eventPrefix: 'vuetable:',
       tableFields: [],
       tableData: null,
       tablePagination: null,
@@ -489,46 +328,27 @@ export default {
       lastScrollPosition: 0,
       scrollBarWidth: '17px', //chrome default
       scrollVisible: false,
+      $_css: {}
     }
   },
-  mounted () {
-    this.normalizeFields()
-    this.normalizeSortOrder()
-    if (this.isFixedHeader) {
-      this.scrollBarWidth = this.getScrollBarWidth() + 'px';
-    }
-    this.$nextTick(function() {
-      this.fireEvent('initialized', this.tableFields)
-    })
 
-    if (this.loadOnStart) {
-      this.loadData()
-    }
-    if (this.isFixedHeader) {
-      let elem = this.$el.getElementsByClassName('vuetable-body-wrapper')[0];
-      if (elem != null) {
-        elem.addEventListener('scroll', this.handleScroll);
-      }
-    }
-  },
-  destroyed () {
-    let elem = this.$el.getElementsByClassName('vuetable-body-wrapper')[0];
-    if (elem != null) {
-      elem.removeEventListener('scroll', this.handleScroll);
-    }
-  },
   computed: {
     version: () => VERSION,
     useDetailRow () {
-      if (this.tableData && this.tableData[0] && this.detailRowComponent !== '' && typeof this.tableData[0][this.trackBy] === 'undefined') {
-        this.warn('You need to define unique row identifier in order for detail-row feature to work. Use `track-by` prop to define one!')
-        return false
-      }
+      if ( ! this.dataIsAvailable) return false
 
       return this.detailRowComponent !== ''
     },
+    dataIsAvailable () {
+      if ( ! this.tableData) return false
+
+      return this.tableData.length > 0
+    },
+    hasRowIdentifier () {
+      return this.tableData && typeof(this.tableData[0][this.trackBy]) !== 'undefined'
+    },
     countVisibleFields () {
-      return this.tableFields.filter(function(field) {
+      return this.tableFields.filter( (field) => {
         return field.visible
       }).length
     },
@@ -565,9 +385,75 @@ export default {
     },
     isFixedHeader () {
       return this.tableHeight != null
+    },
+    vuetable () {
+      return this
     }
   },
+
+  created() {
+    this.mergeCss()
+    this.normalizeFields()
+    this.normalizeSortOrder()
+    this.$nextTick( () => {
+      this.fireEvent('initialized', this.tableFields)
+    })
+  },
+
+  mounted () {
+    if (this.loadOnStart) {
+      this.loadData()
+    }
+
+    if (this.isFixedHeader) {
+      this.scrollBarWidth = this.getScrollBarWidth() + 'px';
+
+      let elem = this.$el.getElementsByClassName('vuetable-body-wrapper')[0];
+      if (elem != null) {
+        elem.addEventListener('scroll', this.handleScroll);
+      }
+    }
+  },
+
+  destroyed () {
+    let elem = this.$el.getElementsByClassName('vuetable-body-wrapper')[0];
+    if (elem != null) {
+      elem.removeEventListener('scroll', this.handleScroll);
+    }
+  },
+
+  watch: {
+    multiSort (newVal, oldVal) {
+      if (newVal === false && this.sortOrder.length > 1) {
+        this.sortOrder.splice(1);
+        this.loadData();
+      }
+    },
+
+    apiUrl (newVal, oldVal) {
+      if (this.reactiveApiUrl && newVal !== oldVal)
+        this.refresh()
+    },
+
+    data (newVal, oldVal) {
+      this.setData(newVal)
+    },
+
+    tableHeight (newVal, oldVal) {
+      this.checkScrollbarVisibility()
+    },
+
+    fields (newVal, oldVal) {
+    	this.normalizeFields();
+    },
+
+    perPage (newVal, oldVal) {
+      this.reload();
+    }
+},
+
   methods: {
+
     getScrollBarWidth () {
       const outer = document.createElement('div');
       const inner = document.createElement('div');
@@ -577,34 +463,39 @@ export default {
 
       inner.style.width = '100%';
 
-
       outer.appendChild(inner);
       document.body.appendChild(outer);
 
-
       const widthWithoutScrollbar = outer.offsetWidth;
-
       outer.style.overflow = 'scroll';
-
       const widthWithScrollbar = inner.offsetWidth;
-
-
       document.body.removeChild(outer);
-
 
       return (widthWithoutScrollbar - widthWithScrollbar);
     },
-    handleScroll (e) { //make sure that the header and the body are aligned when scrolling horizontally on a table that is wider than the viewport
+
+    //make sure that the header and the body are aligned when scrolling horizontally on a table that is wider than the viewport
+    handleScroll (e) {
       let horizontal = e.currentTarget.scrollLeft;
-      if (horizontal != this.lastScrollPosition) { //don't modify header scroll if we are scrolling vertically
+
+      //don't modify header scroll if we are scrolling vertically
+      if (horizontal != this.lastScrollPosition) {
         let header = this.$el.getElementsByClassName('vuetable-head-wrapper')[0]
         if (header != null) {
           header.scrollLeft = horizontal;
         }
         this.lastScrollPosition = horizontal;
       }
-
     },
+
+    mergeCss () {
+      this.$_css = { ...CssSemanticUI.table, ...this.css }
+    },
+
+    bodyClass (base, field) {
+      return [ base, field.dataClass ]
+    },
+
     normalizeFields () {
       if (typeof(this.fields) === 'undefined') {
         this.warn('You need to provide "fields" prop.')
@@ -612,33 +503,52 @@ export default {
       }
 
       this.tableFields = []
-      let self = this
-      let obj
-      this.fields.forEach(function(field, i) {
-        if (typeof (field) === 'string') {
-          obj = {
-            name: field,
-            title: self.setTitle(field),
-            titleClass: '',
-            dataClass: '',
-            callback: null,
-            visible: true,
-          }
-        } else {
-          obj = {
-            name: field.name,
-            width: field.width,
-            title: (field.title === undefined) ? self.setTitle(field.name) : field.title,
-            sortField: field.sortField,
-            titleClass: (field.titleClass === undefined) ? '' : field.titleClass,
-            dataClass: (field.dataClass === undefined) ? '' : field.dataClass,
-            callback: (field.callback === undefined) ? '' : field.callback,
-            visible: (field.visible === undefined) ? true : field.visible,
-          }
-        }
-        self.tableFields.push(obj)
+
+      this.fields.forEach( (field, i) => {
+        this.tableFields.push(this.newField(field, i))
       })
     },
+
+    newField (field, index) {
+      let defaultField = {
+        name: '',
+        // title:
+        // this allow the code to detect undefined title
+        // and replace it with capitalized name instead
+        titleClass: '',
+        dataClass: '',
+        sortField: null,
+        formatter: null,
+        visible: true,
+        width: null,
+        $_index: index,
+      }
+
+      if (typeof(field) === 'string') {
+        return Object.assign({}, defaultField, {
+          name: this.normalizeFieldName(field),
+          title: this.makeTitle(field),
+        })
+      }
+
+      let obj = Object.assign({}, defaultField, field)
+      obj.name = this.normalizeFieldName(obj.name)
+      if (obj.title === undefined) {
+        obj.title = this.makeTitle(obj.name)
+      }
+      if (obj.formatter !== null && typeof(obj.formatter) !== 'function') {
+        console.error(obj.name + ' field formatter must be a function')
+        obj.formatter = null
+      }
+      return obj
+    },
+
+    normalizeFieldName (fieldName) {
+      if (fieldName instanceof Object) return fieldName
+
+      return typeof(fieldName) === 'string' && fieldName.replace('__', this.fieldPrefix)
+    },
+
     setData (data) {
       if (data === null || typeof(data) === 'undefined') return
 
@@ -653,67 +563,72 @@ export default {
       this.tableData = this.getObjectValue(data, this.dataPath, null)
       this.tablePagination = this.getObjectValue(data, this.paginationPath, null)
 
-      this.$nextTick(function() {
-        this.fixHeader()
+      this.$nextTick( () => {
+        this.checkIfRowIdentifierExists()
+        this.updateHeader()
         this.fireEvent('pagination-data', this.tablePagination)
         this.fireEvent('loaded')
       })
     },
-    setTitle (str) {
-      if (this.isSpecialField(str)) {
+
+    checkIfRowIdentifierExists () {
+      if (! this.dataIsAvailable) return
+
+      if ( ! this.hasRowIdentifier) {
+        this.warn('Invalid your data! Use "track-by" prop to specify.')
+        return false
+      }
+
+      return true
+    },
+
+    makeTitle (str) {
+      if (this.isFieldComponent(str)) {
         return ''
       }
 
-      return this.titleCase(str)
+      return this.titleCase(str.replace('.', ' '))
     },
-    getTitle (field) {
+
+    getFieldTitle (field) {
       if (typeof(field.title) === 'function') return field.title()
 
-      return typeof(field.title) === 'undefined'
-        ? field.name.replace('.', ' ')
-        : field.title
+      return field.title
     },
-    renderTitle (field) {
-      let title = this.getTitle(field)
 
-      if (title.length > 0 && this.isInCurrentSortGroup(field) || this.hasSortableIcon(field)) {
-        let style = `opacity:${this.sortIconOpacity(field)};position:relative;float:right`
-        let iconTag = this.showSortIcons ? this.renderIconTag(['sort-icon', this.sortIcon(field)], `style="${style}"`) : ''
-        return title + ' ' + iconTag
-      }
-
-      return title
-    },
-    renderSequence (index) {
-      return this.tablePagination
-        ? this.tablePagination.from + index
-        : index
-    },
     renderNormalField (field, item) {
-      return this.hasCallback(field)
-        ? this.callCallback(field, item)
+      return this.hasFormatter(field)
+        ? this.callFormatter(field, item)
         : this.getObjectValue(item, field.name, '')
     },
-    isSpecialField (fieldName) {
-      return fieldName.slice(0, 2) === '__'
+
+    isFieldComponent (fieldName) {
+      if (fieldName instanceof Object) {
+        // let's assume it is a Vue component
+        return true
+      }
+
+      return fieldName.slice(0, this.fieldPrefix.length) === this.fieldPrefix
+        || fieldName.slice(0, 2) === '__'
     },
+
+    isFieldSlot (fieldName) {
+      return typeof this.$scopedSlots[fieldName] !== 'undefined'
+    },
+
     titleCase (str) {
-      return str.replace(/\w+/g, function(txt) {
+      return str.replace(/\w+/g, (txt) => {
         return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
       })
     },
+
     camelCase (str, delimiter = '_') {
-      let self = this
-      return str.split(delimiter).map(function(item) {
-        return self.titleCase(item)
-      }).join('')
+      return str.split(delimiter).map( (item) => self.titleCase(item) ).join('')
     },
-    notIn (str, arr) {
-      return arr.indexOf(str) === -1
-    },
+
     loadData (success = this.loadSuccess, failed = this.loadFailed) {
       if (this.isDataMode) {
-        this.callDataManager()
+        this.handleDataMode()
         return
       }
 
@@ -726,86 +641,97 @@ export default {
           failed
       ).catch(() => failed())
     },
+
     fetch (apiUrl, httpOptions) {
-      return this.httpFetch
-          ? this.httpFetch(apiUrl, httpOptions)
-          : axios[this.httpMethod](apiUrl, httpOptions)
+      if (this.httpFetch) {
+        return this.httpFetch(apiUrl, httpOptions)
+      }
+
+      if (this.httpMethod === 'get') {
+        return axios.get(apiUrl, httpOptions)
+      }
+      else { // Is a POST request
+        let params = httpOptions.params
+        delete httpOptions.params
+        return axios.post(apiUrl, params, httpOptions)
+      }
     },
+
     loadSuccess (response) {
       this.fireEvent('load-success', response)
 
-      let body = this.transform(response.data)
+      let body = this.transform ? this.transform(response.data) : response.data
 
       this.tableData = this.getObjectValue(body, this.dataPath, null)
       this.tablePagination = this.getObjectValue(body, this.paginationPath, null)
 
       if (this.tablePagination === null) {
         this.warn('vuetable: pagination-path "' + this.paginationPath + '" not found. '
-          + 'It looks like the data returned from the sever does not have pagination information '
+          + 'It looks like the data returned from the server does not have pagination information '
           + "or you may have set it incorrectly.\n"
           + 'You can explicitly suppress this warning by setting pagination-path="".'
         )
       }
 
-      this.$nextTick(function() {
-        this.fixHeader()
+      this.$nextTick( () => {
+        this.checkIfRowIdentifierExists()
+        this.updateHeader()
         this.fireEvent('pagination-data', this.tablePagination)
         this.fireEvent('loaded')
       })
     },
-    fixHeader() {
-      if (!this.isFixedHeader) {
-        return;
-      }
 
-      let elem = this.$el.getElementsByClassName('vuetable-body-wrapper')[0]
-      if (elem != null) {
-        if (elem.scrollHeight > elem.clientHeight) {
-          this.scrollVisible = true;
-        }
-        else {
-          this.scrollVisible = false;
-        }
-      }
+    updateHeader () {
+      // $nextTick doesn't seem to work in all cases. This might be because
+      // $nextTick is finished before the transition element (just my guess)
+      //
+      // the scrollHeight value does not yet changed, causing scrollVisible
+      // to remain "true", therefore, the header gutter never gets updated
+      // to reflect the display of scrollbar in the table body.
+      // setTimeout 80ms seems to work in this case.
+      setTimeout(this.checkScrollbarVisibility, 80)
     },
+
+    checkScrollbarVisibility () {
+      this.$nextTick( () => {
+        let elem = this.$el.getElementsByClassName('vuetable-body-wrapper')[0]
+        if (elem != null) {
+          this.scrollVisible = (elem.scrollHeight > elem.clientHeight)
+          this.fireEvent('scrollbar-visible', this.scrollVisible)
+        }
+      })
+    },
+
     loadFailed (response) {
       console.error('load-error', response)
       this.fireEvent('load-error', response)
       this.fireEvent('loaded')
     },
-    transform (data) {
-      let func = 'transform'
 
-      if (this.parentFunctionExists(func)) {
-          return this.$parent[func].call(this.$parent, data)
+    fireEvent () {
+      if (arguments.length === 1) {
+        return this.$emit(this.eventPrefix + arguments[0])
       }
 
-      return data
-    },
-    parentFunctionExists (func) {
-      return (func !== '' && typeof this.$parent[func] === 'function')
-    },
-    callParentFunction (func, args, defaultValue = null) {
-      if (this.parentFunctionExists(func)) {
-        return this.$parent[func].call(this.$parent, args)
+      if (arguments.length > 1) {
+        let args = Array.from(arguments)
+        args[0] = this.eventPrefix + args[0]
+        return this.$emit.apply(this, args)
       }
+    },
 
-      return defaultValue
-    },
-    fireEvent (eventName, args) {
-      this.$emit(this.eventPrefix + eventName, args)
-    },
     warn (msg) {
       if (!this.silent) {
         console.warn(msg)
       }
     },
+
     getAllQueryParams () {
       let params = {}
 
       if (typeof(this.queryParams) === 'function') {
         params = this.queryParams(this.sortOrder, this.currentPage, this.perPage)
-        return typeof(params) !== 'object' ? {} : params
+        return typeof(params) === 'object' ? params : {}
       }
 
       params[this.queryParams.sort] = this.getSortParam()
@@ -814,29 +740,23 @@ export default {
 
       return params
     },
+
     getSortParam () {
       if (!this.sortOrder || this.sortOrder.field == '') {
         return ''
       }
 
-      if (typeof this.$parent['getSortParam'] === 'function') {
-        return this.$parent['getSortParam'].call(this.$parent, this.sortOrder)
+      if (typeof this.sortParams === 'function') {
+        return this.sortParams(this.sortOrder)
       }
 
       return this.getDefaultSortParam()
     },
+
     getDefaultSortParam () {
-      let result = '';
-
-      for (let i = 0; i < this.sortOrder.length; i++) {
-        let fieldName = (typeof this.sortOrder[i].sortField === 'undefined')
-          ? this.sortOrder[i].field
-          : this.sortOrder[i].sortField;
-
-        result += fieldName + '|' + this.sortOrder[i].direction + ((i+1) < this.sortOrder.length ? ',' : '');
-      }
-      return result;
+      return this.sortOrder.map( (item) => `${item.sortField}|${item.direction}`).join(',')
     },
+
     getAppendParams (params) {
       for (let x in this.appendParams) {
         params[x] = this.appendParams[x]
@@ -844,21 +764,11 @@ export default {
 
       return params
     },
-    extractName (string) {
-      return string.split(':')[0].trim()
-    },
-    extractArgs (string) {
-      return string.split(':')[1]
-    },
+
     isSortable (field) {
-      return !(typeof field.sortField === 'undefined')
+      return field.sortField !== null
     },
-    isInCurrentSortGroup (field) {
-      return this.currentSortOrderPosition(field) !== false;
-    },
-    hasSortableIcon (field) {
-      return this.isSortable(field) && this.css.sortableIcon != ''
-    },
+
     currentSortOrderPosition (field) {
       if ( ! this.isSortable(field)) {
         return false
@@ -872,9 +782,11 @@ export default {
 
       return false;
     },
+
     fieldIsInSortOrderPosition (field, i) {
       return this.sortOrder[i].field === field.name && this.sortOrder[i].sortField === field.sortField
     },
+
     orderBy (field, event) {
       if ( ! this.isSortable(field) ) return
 
@@ -887,33 +799,48 @@ export default {
         this.singleColumnSort(field)
       }
 
-      this.currentPage = 1    // reset page index
+      this.currentPage = this.firstPage    // reset page index
       if (this.apiMode || this.dataManager) {
         this.loadData()
       }
     },
+
+    addSortColumn (field, direction) {
+      this.sortOrder.push({
+        field: field.name,
+        sortField: field.sortField,
+        direction: 'asc'
+      });
+    },
+
+    removeSortColumn (index) {
+      this.sortOrder.splice(index, 1);
+    },
+
+    setSortColumnDirection (index, direction) {
+      this.sortOrder[index].direction = direction
+    },
+
     multiColumnSort (field) {
       let i = this.currentSortOrderPosition(field);
 
-      if(i === false) { //this field is not in the sort array yet
-        this.sortOrder.push({
-          field: field.name,
-          sortField: field.sortField,
-          direction: 'asc'
-        });
+      if (i === false) { //this field is not in the sort array yet
+        this.addSortColumn(field, 'asc')
       } else { //this field is in the sort array, now we change its state
-        if(this.sortOrder[i].direction === 'asc') {
+        if (this.sortOrder[i].direction === 'asc') {
           // switch direction
-          this.sortOrder[i].direction = 'desc'
+          this.setSortColumnDirection(i, 'desc')
         } else {
-          //remove sort condition
-          this.sortOrder.splice(i, 1);
+          this.removeSortColumn(i)
         }
       }
     },
+
     singleColumnSort (field) {
       if (this.sortOrder.length === 0) {
-        this.clearSortOrder()
+        // this.clearSortOrder()
+        this.addSortColumn(field, 'asc')
+        return
       }
 
       this.sortOrder.splice(1); //removes additional columns
@@ -928,89 +855,30 @@ export default {
       this.sortOrder[0].field = field.name
       this.sortOrder[0].sortField = field.sortField
     },
+
     clearSortOrder () {
-      this.sortOrder.push({
-        field: '',
-        sortField: '',
-        direction: 'asc'
-      });
+      this.sortOrder = []
     },
-    sortClass (field) {
-      let cls = ''
-      let i = this.currentSortOrderPosition(field)
 
-      if (i !== false) {
-        cls = (this.sortOrder[i].direction == 'asc') ? this.css.ascendingClass : this.css.descendingClass
+    hasFormatter (item) {
+      return typeof(item.formatter) === 'function'
+    },
+
+    callFormatter (field, item) {
+      if ( ! this.hasFormatter(field)) return
+
+      if (typeof(field.formatter) === 'function') {
+       return field.formatter(this.getObjectValue(item, field.name), this)
       }
-
-      return cls
     },
-    sortIcon (field) {
-      let cls = this.css.sortableIcon
-      let i = this.currentSortOrderPosition(field)
 
-      if (i !== false) {
-        cls = (this.sortOrder[i].direction == 'asc') ? this.css.ascendingIcon : this.css.descendingIcon
-      }
-
-      return cls;
-    },
-    sortIconOpacity (field) {
-      /*
-       * fields with stronger precedence have darker color
-       *
-       * if there are few fields, we go down by 0.3
-       * ex. 2 fields are selected: 1.0, 0.7
-       *
-       * if there are more we go down evenly on the given spectrum
-       * ex. 6 fields are selected: 1.0, 0.86, 0.72, 0.58, 0.44, 0.3
-       */
-      let max = 1.0,
-          min = 0.3,
-          step = 0.3
-
-      let count = this.sortOrder.length;
-      let current = this.currentSortOrderPosition(field)
-
-
-      if(max - count * step < min) {
-        step = (max - min) / (count-1)
-      }
-
-      let opacity = max - current * step
-
-      return opacity
-    },
-    hasCallback (item) {
-      return item.callback ? true : false
-    },
-    callCallback (field, item) {
-      if ( ! this.hasCallback(field)) return
-
-      if(typeof(field.callback) == 'function') {
-       return field.callback(this.getObjectValue(item, field.name))
-      }
-
-      let args = field.callback.split('|')
-      let func = args.shift()
-
-      if (typeof this.$parent[func] === 'function') {
-        let value = this.getObjectValue(item, field.name)
-
-        return (args.length > 0)
-          ? this.$parent[func].apply(this.$parent, [value].concat(args))
-          : this.$parent[func].call(this.$parent, value)
-      }
-
-      return null
-    },
     getObjectValue (object, path, defaultValue) {
       defaultValue = (typeof defaultValue === 'undefined') ? null : defaultValue
 
       let obj = object
       if (path.trim() != '') {
         let keys = path.split('.')
-        keys.forEach(function(key) {
+        keys.forEach( (key) => {
           if (obj !== null && typeof obj[key] !== 'undefined' && obj[key] !== null) {
             obj = obj[key]
           } else {
@@ -1021,133 +889,69 @@ export default {
       }
       return obj
     },
-    toggleCheckbox (dataItem, fieldName, event) {
-      let isChecked = event.target.checked
-      let idColumn = this.trackBy
 
-      if (dataItem[idColumn] === undefined) {
-        this.warn('__checkbox field: The "'+this.trackBy+'" field does not exist! Make sure the field you specify in "track-by" prop does exist.')
-        return
-      }
-
-      let key = dataItem[idColumn]
-      if (isChecked) {
-        this.selectId(key)
-      } else {
-        this.unselectId(key)
-      }
-      this.$emit('vuetable:checkbox-toggled', isChecked, dataItem)
-    },
     selectId (key) {
       if ( ! this.isSelectedRow(key)) {
         this.selectedTo.push(key)
       }
     },
+
     unselectId (key) {
-      this.selectedTo = this.selectedTo.filter(function(item) {
+      this.selectedTo = this.selectedTo.filter( (item) => {
         return item !== key
       })
     },
+
     isSelectedRow (key) {
       return this.selectedTo.indexOf(key) >= 0
     },
-    rowSelected (dataItem, fieldName){
-      let idColumn = this.trackBy
-      let key = dataItem[idColumn]
 
-      return this.isSelectedRow(key)
+    clearSelectedValues () {
+      this.selectedTo = []
     },
-    checkCheckboxesState (fieldName) {
-      if (! this.tableData) return
 
-      let self = this
-      let idColumn = this.trackBy
-      let selector = 'th.vuetable-th-checkbox-' + idColumn + ' input[type=checkbox]'
-      let els = document.querySelectorAll(selector)
-
-      //fixed:document.querySelectorAll return the typeof nodeList not array
-      if (els.forEach===undefined)
-        els.forEach=function(cb){
-          [].forEach.call(els, cb);
-        }
-
-      // count how many checkbox row in the current page has been checked
-      let selected = this.tableData.filter(function(item) {
-        return self.selectedTo.indexOf(item[idColumn]) >= 0
-      })
-
-      // count == 0, clear the checkbox
-      if (selected.length <= 0) {
-        els.forEach(function(el) {
-          el.indeterminate = false
-        })
-        return false
-      }
-      // count > 0 and count < perPage, set checkbox state to 'indeterminate'
-      else if (selected.length < this.perPage) {
-        els.forEach(function(el) {
-          el.indeterminate = true
-        })
-        return true
-      }
-      // count == perPage, set checkbox state to 'checked'
-      else {
-        els.forEach(function(el) {
-          el.indeterminate = false
-        })
-        return true
-      }
-    },
-    toggleAllCheckboxes (fieldName, event) {
-      let self = this
-      let isChecked = event.target.checked
-      let idColumn = this.trackBy
-
-      if (isChecked) {
-        this.tableData.forEach(function(dataItem) {
-          self.selectId(dataItem[idColumn])
-        })
-      } else {
-        this.tableData.forEach(function(dataItem) {
-          self.unselectId(dataItem[idColumn])
-        })
-      }
-      this.$emit('vuetable:checkbox-toggled-all', isChecked)
-    },
     gotoPreviousPage () {
-      if (this.currentPage > 1) {
+      if (this.currentPage > this.firstPage) {
         this.currentPage--
         this.loadData()
       }
     },
+
     gotoNextPage () {
       if (this.currentPage < this.tablePagination.last_page) {
         this.currentPage++
         this.loadData()
       }
     },
+
     gotoPage (page) {
-      if (page != this.currentPage && (page > 0 && page <= this.tablePagination.last_page)) {
+      if (page != this.currentPage && (page >= this.firstPage && page <= this.tablePagination.last_page)) {
         this.currentPage = page
         this.loadData()
       }
     },
+
     isVisibleDetailRow (rowId) {
       return this.visibleDetailRows.indexOf( rowId ) >= 0
     },
+
     showDetailRow (rowId) {
       if (!this.isVisibleDetailRow(rowId)) {
         this.visibleDetailRows.push(rowId)
       }
+      this.checkScrollbarVisibility()
     },
+
     hideDetailRow (rowId) {
       if (this.isVisibleDetailRow(rowId)) {
         this.visibleDetailRows.splice(
           this.visibleDetailRows.indexOf(rowId),
           1
         )
+        this.updateHeader()
       }
     },
+
     toggleDetailRow (rowId) {
       if (this.isVisibleDetailRow(rowId)) {
         this.hideDetailRow(rowId)
@@ -1155,29 +959,28 @@ export default {
         this.showDetailRow(rowId)
       }
     },
+
     showField (index) {
       if (index < 0 || index > this.tableFields.length) return
 
       this.tableFields[index].visible = true
     },
+
     hideField (index) {
       if (index < 0 || index > this.tableFields.length) return
 
       this.tableFields[index].visible = false
     },
+
     toggleField (index) {
       if (index < 0 || index > this.tableFields.length) return
 
       this.tableFields[index].visible = ! this.tableFields[index].visible
     },
-    renderIconTag (classes, options = '') {
-      return typeof(this.css.renderIcon) === 'undefined'
-        ? `<i class="${classes.join(' ')}" ${options}></i>`
-        : this.css.renderIcon(classes, options)
-    },
+
     makePagination (total = null, perPage = null, currentPage = null) {
       let pagination = {}
-      total = total === null ? this.dataTotal : total
+      total = total === null ? 0 : total
       perPage = perPage === null ? this.perPage : perPage
       currentPage = currentPage === null ? this.currentPage : currentPage
 
@@ -1192,61 +995,133 @@ export default {
         'to': Math.min(currentPage * perPage, total)
       }
     },
+
     normalizeSortOrder () {
-      this.sortOrder.forEach(function(item) {
+      this.sortOrder.forEach( (item) => {
         item.sortField = item.sortField || item.field
       })
     },
-    callDataManager () {
-      if (this.dataManager === null && this.data === null) return
 
-      if (Array.isArray(this.data)) {
-        return this.setData(this.data)
-      } 
-      
-      this.normalizeSortOrder()
-
-      return this.setData(
-        this.dataManager
-          ? this.dataManager(this.sortOrder, this.makePagination())
-          : this.data
-      )
-    },
-    onRowClass (dataItem, index) {
-      if (this.rowClassCallback !== '') {
-        this.warn('"row-class-callback" prop is deprecated, please use "row-class" prop instead.')
+    handleDataMode () {
+      // data is array
+      if (this.data !== null && Array.isArray(this.data)) {
+        this.setData(this.data)
         return
       }
 
+      // data must be an object, check if dataManager is present
+      if (this.dataManager) {
+        this.callDataManager()
+      } else {
+        this.setData(this.data)
+      }
+    },
+
+    callDataManager () {
+      const result = this.dataManager(this.sortOrder, this.makePagination())
+
+      if (this.isPromiseObject(result)) {
+        result.then(data => this.setData(data))
+      } else {
+        this.setData(result)
+      }
+    },
+
+    isObject (unknown) {
+      return typeof(unknown) === "object" && unknown !== null
+    },
+
+    isPromiseObject (unknown) {
+      return this.isObject(unknown) && typeof(unknown.then) === "function"
+    },
+
+    onRowClass (dataItem, index) {
       if (typeof(this.rowClass) === 'function') {
         return this.rowClass(dataItem, index)
       }
 
       return this.rowClass
     },
-    onRowChanged (dataItem) {
-      this.fireEvent('row-changed', dataItem)
+
+    onDetailRowClass (dataItem, index) {
+      if (typeof(this.detailRowClass) === 'function') {
+        return this.detailRowClass(dataItem, index)
+      }
+
+      return this.detailRowClass
+    },
+
+    onRowClicked (dataItem, dataIndex, event) {
+      this.fireEvent('row-clicked', { data: dataItem, index: dataIndex, event: event })
       return true
     },
-    onRowClicked (dataItem, event) {
-      this.$emit(this.eventPrefix + 'row-clicked', dataItem, event)
-      return true
+
+    onRowDoubleClicked (dataItem, dataIndex, event) {
+      this.fireEvent('row-dblclicked', { data: dataItem, index: dataIndex, event: event })
     },
-    onRowDoubleClicked (dataItem, event) {
-      this.$emit(this.eventPrefix + 'row-dblclicked', dataItem, event)
+
+    onDetailRowClick (dataItem, dataIndex, event) {
+      this.fireEvent('detail-row-clicked', { data: dataItem, index: dataIndex, event: event })
     },
-    onDetailRowClick (dataItem, event) {
-      this.$emit(this.eventPrefix + 'detail-row-clicked', dataItem, event)
+
+    onCellClicked (dataItem, dataIndex, field, event) {
+      this.fireEvent('cell-clicked', { data: dataItem, index: dataIndex, field: field, event: event })
     },
-    onCellClicked (dataItem, field, event) {
-      this.$emit(this.eventPrefix + 'cell-clicked', dataItem, field, event)
+
+    onCellDoubleClicked (dataItem, dataIndex, field, event) {
+      this.fireEvent('cell-dblclicked', { data: dataItem, index: dataIndex, field: field, event: event })
     },
-    onCellDoubleClicked (dataItem, field, event) {
-      this.$emit(this.eventPrefix + 'cell-dblclicked', dataItem, field, event)
+
+    onCellRightClicked (dataItem, dataIndex, field, event) {
+      this.fireEvent('cell-rightclicked', { data: dataItem, index: dataIndex, field: field, event: event })
     },
-    onCellRightClicked (dataItem, field, event) {
-      this.$emit(this.eventPrefix + 'cell-rightclicked', dataItem, field, event)
+
+    onMouseOver (dataItem, dataIndex, event) {
+      this.fireEvent('row-mouseover', { data: dataItem, index: dataIndex, event: event })
     },
+
+    onFieldEvent (type, payload) {
+      this.fireEvent('field-event', type, payload, this)
+    },
+
+    onHeaderEvent (type, payload) {
+      this.fireEvent('header-event', type, payload, this)
+    },
+
+    onCheckboxToggled (isChecked, fieldName, dataItem) {
+      let idColumn = this.trackBy
+
+      if (dataItem[idColumn] === undefined) {
+        this.warn('checkbox field: The "'+this.trackBy+'" field does not exist! Make sure the field you specify in "track-by" prop does exist.')
+        return
+      }
+
+      let key = dataItem[idColumn]
+      if (isChecked) {
+        this.selectId(key)
+      } else {
+        this.unselectId(key)
+      }
+
+      this.fireEvent('checkbox-toggled', isChecked, fieldName)
+    },
+
+    onCheckboxToggledAll (isChecked) {
+      let idColumn = this.trackBy
+
+      if (isChecked) {
+        this.tableData.forEach( (dataItem) => {
+          this.selectId(dataItem[idColumn])
+        })
+      } else {
+        this.tableData.forEach( (dataItem) => {
+          this.unselectId(dataItem[idColumn])
+        })
+      }
+
+      this.fireEvent('checkbox-toggled-all', isChecked)
+    },
+
     /*
      * API for externals
      */
@@ -1259,86 +1134,54 @@ export default {
         this.gotoPage(page)
       }
     },
+
     reload () {
       return this.loadData()
     },
+
     refresh () {
-      this.currentPage = 1
+      this.currentPage = this.firstPage
       return this.loadData()
     },
+
     resetData () {
       this.tableData = null
       this.tablePagination = null
       this.fireEvent('data-reset')
-    }
+    },
   }, // end: methods
-  watch: {
-    'multiSort' (newVal, oldVal) {
-      if (newVal === false && this.sortOrder.length > 1) {
-        this.sortOrder.splice(1);
-        this.loadData();
-      }
-    },
-    'apiUrl'  (newVal, oldVal) {
-      if(this.reactiveApiUrl && newVal !== oldVal)
-        this.refresh()
-    },
-    'data' (newVal, oldVal) {
-      this.setData(newVal)
-    },
-    'tableHeight' (newVal, oldVal) {
-      this.fixHeader()
-    }
-  },
 }
 </script>
 
-<style scoped>
+<style>
   [v-cloak] {
     display: none;
+  }
+  table.vuetable.fixed-header {
+    table-layout: fixed;
   }
   .vuetable th.sortable:hover {
     color: #2185d0;
     cursor: pointer;
   }
-  .vuetable-body-wrapper {
-    position:relative;
-    overflow-y:auto;
-  }
   .vuetable-head-wrapper {
     overflow-x: hidden;
   }
-  .vuetable-actions {
-    width: 15%;
-    padding: 12px 0px;
-    text-align: center;
+  .vuetable-head-wrapper table.vuetable {
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
   }
-  .vuetable-pagination {
-    background: #f9fafb !important;
+  .vuetable-body-wrapper.fixed-header {
+    position:relative;
+    overflow-y:auto;
   }
-  .vuetable-pagination-info {
-    margin-top: auto;
-    margin-bottom: auto;
+  .vuetable-body-wrapper table.vuetable.fixed-header {
+    border-top:none !important;
+    margin-top:0 !important;
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
   }
   .vuetable-empty-result {
     text-align: center;
-  }
-  .vuetable-clip-text {
-    white-space: pre-wrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    display: block;
-  }
-  .vuetable-semantic-no-top {
-    border-top:none !important;
-    margin-top:0 !important;
-  }
-  .vuetable-fixed-layout {
-    table-layout: fixed;
-  }
-  .vuetable-gutter-col {
-    padding: 0 !important;
-    border-left: none  !important;
-    border-right: none  !important;
   }
 </style>


### PR DESCRIPTION
This allows adding a new data attrtibute `data-label` to table fields. A custom value can be used by passing a string to a new field option `dataLabel`. If no `dataClass` option exists on the field, the `title` option will be used instead.

The need for this arose when using beufys `has-mobile-cards` class for small screens. Buefy looks for a `data-label` attribute on the element to set headers when in mobile view.

Solves #538.