### PR TITLE
Add a mixin for enabling infinite scroll

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -117,10 +117,11 @@ import axios from 'axios'
 import VuetableRowHeader from './VuetableRowHeader'
 import VuetableColGroup from './VuetableColGroup'
 import CssSemanticUI from './VuetableCssSemanticUI.js'
+import InfiniteScrollMixin from './VuetableInfiniteScrollMixin'
 
 export default {
   name: 'Vuetable',
-
+  mixins: [InfiniteScrollMixin],
   components: {
     VuetableRowHeader,
     VuetableColGroup,
@@ -660,7 +661,8 @@ export default {
 
       let body = this.transform ? this.transform(response.data) : response.data
 
-      this.tableData = this.getObjectValue(body, this.dataPath, null)
+      let newData = this.getObjectValue(body, this.dataPath, null)
+      this.tableData = this.infiniteScroll ? this.tableData.concat(newData) : newData
       this.tablePagination = this.getObjectValue(body, this.paginationPath, null)
 
       if (this.tablePagination === null) {

--- a/src/components/VuetableInfiniteScrollMixin.vue
+++ b/src/components/VuetableInfiniteScrollMixin.vue
@@ -30,7 +30,6 @@
       },
     },
     mounted() {
-      console.log('in mounted form mixing')
       if (!this.isFixedHeader) return
       const tBody = this.$el.getElementsByClassName('vuetable-body-wrapper')[0]
       const rowElem = this.$el.querySelectorAll('tbody.vuetable-body tr')[0]

--- a/src/components/VuetableInfiniteScrollMixin.vue
+++ b/src/components/VuetableInfiniteScrollMixin.vue
@@ -1,0 +1,50 @@
+<script>
+  export default {
+    data() {
+      return {
+        isLoadingData: false,
+        rowElemHeight: 0,
+      }
+    },
+    props: {
+      infiniteScroll: {
+        type: Boolean,
+        default: false,
+      },
+      numRowsToBottom: {
+        type: Number,
+        default: 10,
+      },
+    },
+    methods: {
+      handleInfiniteScroll(e) {
+        const { clientHeight, scrollTop, scrollHeight } = e.target
+        if (this.isLoadingData) return
+        if (clientHeight + scrollTop > scrollHeight - (this.numRowsToBottom * this.rowElemHeight)) {
+          this.isLoadingData = true
+          this.gotoNextPage()
+        }
+      },
+      dataReceived() {
+        this.isLoadingData = false
+      },
+    },
+    mounted() {
+      console.log('in mounted form mixing')
+      if (!this.isFixedHeader) return
+      const tBody = this.$el.getElementsByClassName('vuetable-body-wrapper')[0]
+      const rowElem = this.$el.querySelectorAll('tbody.vuetable-body tr')[0]
+      if (!tBody || !rowElem) return
+      this.rowElemHeight = rowElem.clientHeight
+      tBody.addEventListener('scroll', this.handleInfiniteScroll)
+      this.$on('vuetable:loaded', this.dataReceived)
+    },
+    destroyed() {
+      const tBody = this.$el.getElementsByClassName('vuetable-body-wrapper')[0]
+      if (tBody != null) {
+        tBody.removeEventListener('scroll', this.handleInfiniteScroll)
+        this.$off('vuetable:loaded', this.dataReceived)
+      }
+    },
+  }
+</script>


### PR DESCRIPTION
First of all, thanks for the neat and great plugin!
I needed a table component which could support infinite scroll and column resize(without sacrificing other features). Looking at the issues a few people were asking about the same. Thought of giving it a try. Please check if it is okay. 
The `$on` event listeners can be removed, but that will require more code changes in the main file. Let me know if you are okay with that. 
Right now it works only in `data-mode`, can be made to work in API mode too. 