### PR TITLE
Add docs for yarn to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you any question, please post your questions in the "Issues" section of [this
 ## NPM
 
 ```shell
-npm install vuetable-2@next
+npm install vuetable-2@next --save
 ```
 
 ## Yarn

--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ If you any question, please post your questions in the "Issues" section of [this
 ## NPM
 
 ```shell
-npm install vuetable-2@next --save-dev
+npm install vuetable-2@next
+```
+
+## Yarn
+
+```shell
+yarn add vuetable-2@next
 ```
 
 ## Javascript via CDN


### PR DESCRIPTION
The Yarn package manager (fully compatible with the NPM registry) has seen a lot of community adoption.  __Most notably,__ [Vue](https://github.com/vuejs/vue) itself uses yarn.

This pull request adds documentation describing how to install `vuetable-2` with yarn to the `README`.