### PR TITLE
Fix typescript field component compatibility

### DIFF
--- a/src/components/VuetableColGroup.vue
+++ b/src/components/VuetableColGroup.vue
@@ -34,7 +34,7 @@ export default {
 
   methods: {
     columnClass (field, fieldIndex) {
-      let fieldName = typeof(field.name) === "object" && field.name !== null
+      let fieldName = (typeof(field.name) === "object" || typeof(field.name) === "function") && field.name !== null
         ? field.name.name
         : field.name
       fieldName = fieldName.replace(this.fieldPrefix, "")


### PR DESCRIPTION
In Typescript, export of Vue component returns typeof(field.name) = function instead of object. This causes issues when trying to use field components, because fieldName.replace in VuetableColGroup only checks for object type and returns "fieldName.replace is not a function".

Example method signature that causes issues:

```
import { Vue } from 'vue-property-decorator';

export default class VuetableCustomCheckbox extends Vue {
  ...
}
```

Example import and use in another file:

```
import { Vue } from 'vue-property-decorator';
import Vuetable from 'vuetable-2/src/components/Vuetable.vue';
import VuetableCustomCheckbox from '@/vuetable/VuetableCustomCheckbox.vue';

@Component({
  name: 'custom-vue-table',
  components: {
    Vuetable,
    VuetableCustomCheckbox,
  },

  export default class TicketsTable extends Vue {
    private fields: TableFieldItem[] = [
      {
        name: VuetableCustomCheckbox,
        title: '',
        sortField: null,
        titleClass: 'text-xs-left',
        dataClass: 'text-xs-left',
      } as Object,
    ]
  }
})
```
