### PR TITLE
Fixed checkbox state when perPage exceeds table data

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -1083,8 +1083,8 @@ export default {
         })
         return false
       }
-      // count > 0 and count < perPage, set checkbox state to 'indeterminate'
-      else if (selected.length < this.perPage) {
+      // count > 0 and count < countTableData, set checkbox state to 'indeterminate'
+      else if (selected.length < this.countTableData) {
         els.forEach(function(el) {
           el.indeterminate = true
         })


### PR DESCRIPTION
The checkbox shows wrong state which is indeterminate when perPage is bigger than count of table data (actually total data). Count of selected rows should be compared with rows of table data which is displayed