### PR TITLE
Add API Property

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -150,6 +150,10 @@ export default {
       type: Boolean,
       default: true
     },
+    api: {
+      default: axios,
+      type: Function
+    },
     apiMode: {
       type: Boolean,
       default: true
@@ -646,12 +650,12 @@ export default {
       }
 
       if (this.httpMethod === 'get') {
-        return axios.get(apiUrl, httpOptions)
+        return this.api.get(apiUrl, httpOptions)
       }
       else { // Is a POST request
         let params = httpOptions.params
         delete httpOptions.params
-        return axios.post(apiUrl, params, httpOptions)
+        return this.api.post(apiUrl, params, httpOptions)
       }
     },
 


### PR DESCRIPTION
I have one Axios instance with baseURL and authentication headers, which I use in all components. Adding the API property, allows me to use the same instance for all Vuetables.

For Example:
```html
<!-- MyVueTable.vue -->
<Vuetable
    :api="axiosInstance"
    :apiUrl="devices/"
/>
``` 

```javascript
// MyVueTable.vue
import {axiosInstance} from '@/admin'

export default {
  setup() {
     return {
       axiosInstance
     }
  }
}
```

```javascript
//admin.js
const axiosInstance = axios.create({
    baseURL: 'http://127.0.0.1:8000/',
    timeout: 0,
    default: {headers: {Authorization: 'Bearer: XXX'}}
});
```