### PR TITLE
Fix @vuetable:header event

### DIFF
--- a/src/components/VuetableRowHeader.vue
+++ b/src/components/VuetableRowHeader.vue
@@ -11,7 +11,6 @@
             :key="fieldIndex"
             :class="headerClass('vuetable-th-component', field)"
             :style="{width: field.width}"
-            @vuetable:header-event="vuetable.onHeaderEvent"
             @click="onColumnHeaderClicked(field, $event)"
           ></component>
         </template>
@@ -45,7 +44,7 @@ import VuetableColGutter from './VuetableColGutter'
 
 export default {
   components: {
-    'vuetable-field-checkbox': VuetableFieldCheckbox, 
+    'vuetable-field-checkbox': VuetableFieldCheckbox,
     'vuetable-field-handle'  : VuetableFieldHandle,
     'vuetable-field-sequence': VuetableFieldSequence,
     VuetableColGutter
@@ -188,6 +187,7 @@ export default {
 
     onColumnHeaderClicked (field, event) {
       this.vuetable.orderBy(field, event)
+      this.vuetable.onHeaderEvent(field, event)
     }
   }
 }


### PR DESCRIPTION
Fix the @vuetable:header-event not being thrown with the following setup:
```html
<Vuetable
    :api-mode="false"
    :data="objects"
    :fields="fields"
    :sort-order="sortOrder"
    @vuetable:header-event="onHeaderEvent"
/>
```