### PR TITLE
Add a loader slot and loading property

### DIFF
--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -91,7 +91,14 @@
             </transition>
           </template>
         </template>
-        <template v-if="displayEmptyDataRow">
+        <template v-if="displayLoader">
+          <tr>
+            <td :colspan="countVisibleFields">
+              <slot name="loader"/>
+            </td>
+          </tr>
+        </template>
+        <template v-else-if="displayEmptyDataRow">
           <tr>
             <td :colspan="countVisibleFields"
               class="vuetable-empty-result"
@@ -312,6 +319,10 @@ export default {
       default() {
         return 'vuetable:'
       }
+    },
+    loading: {
+      default: false,
+      type: Boolean
     }
   },
 
@@ -358,6 +369,9 @@ export default {
     },
     displayEmptyDataRow () {
       return this.countTableData === 0 && this.noDataTemplate.length > 0
+    },
+    displayLoader() {
+      return this.loading && this.isFieldSlot('loader')
     },
     lessThanMinRows () {
       if (this.tableData === null || this.tableData.length === 0) {


### PR DESCRIPTION
I needed a loader to be shown inside the table.

Example:

```html
<Vuetable
    :api-mode="false"
    :css="css.table"
    :data="objects"
    :event-prefix="''"
    :fields="fields"
    :loading="loadingOrIncomplete"
    @header-event="onHeaderEvent">
    <div class="ui basic segment" slot="loader">
        <div class="ui active inverted dimmer">
            <div class="ui text loader">{{loadingText}}</div>
        </div>
    </div>
</Vuetable>
```

Screenshots:
![Screenshot 2020-02-17 at 14 52 35](https://user-images.githubusercontent.com/661673/74659752-2f136a80-5195-11ea-881a-10e280e6d86e.png)
![Screenshot 2020-02-17 at 14 52 42](https://user-images.githubusercontent.com/661673/74660195-f32cd500-5195-11ea-8cb9-18572bb9b72b.png)
