### PR TITLE
allow for a field to default to sorting descending

### DIFF
--- a/docs/Sorting.md
+++ b/docs/Sorting.md
@@ -53,6 +53,10 @@ new Vue({
 })
 ```
 
+### Default sort direction
+
+If a field wants to be sorted descending by default, you can specify `defaultSortDirection: 'desc'` in the field definition.
+
 ### Multi-column Sorting
 
 Multi-column sorting can be enabled by setting `multi-sort` prop value to `true`. 

--- a/src/components/Vuetable.vue
+++ b/src/components/Vuetable.vue
@@ -630,6 +630,7 @@ export default {
             width: field.width,
             title: (field.title === undefined) ? self.setTitle(field.name) : field.title,
             sortField: field.sortField,
+            defaultSortDirection: field.defaultSortDirection,
             titleClass: (field.titleClass === undefined) ? '' : field.titleClass,
             dataClass: (field.dataClass === undefined) ? '' : field.dataClass,
             callback: (field.callback === undefined) ? '' : field.callback,
@@ -923,7 +924,7 @@ export default {
         this.sortOrder[0].direction = this.sortOrder[0].direction === 'asc' ? 'desc' : 'asc'
       } else {
         // reset sort direction
-        this.sortOrder[0].direction = 'asc'
+        this.sortOrder[0].direction = field.defaultSortDirection || 'asc'
       }
       this.sortOrder[0].field = field.name
       this.sortOrder[0].sortField = field.sortField

--- a/src/main.js
+++ b/src/main.js
@@ -228,6 +228,7 @@ let tableColumns = [
         : `<i class="orange birthday icon"></i> ${lang['birthdate']}`
     },
     sortField: 'birthdate',
+    defaultSortDirection: 'desc',
     width: '100px',
     callback: 'formatDate|D/MM/Y'
   },


### PR DESCRIPTION
I have a currency field in a table that's mostly nil; the most common thing a user would want to do is see this field by highest-numbers first.  

This patch allows one to specify that a particular field should sort descending by default.
 